### PR TITLE
Add design doc for cloud-managed and standalone AFS architecture

### DIFF
--- a/cli/afs_commands.go
+++ b/cli/afs_commands.go
@@ -159,6 +159,14 @@ func cmdImport(args []string) error {
 	metadataDuration := step.elapsed()
 	step.succeed(initialSavepoint)
 
+	step = startStep("Initializing live workspace")
+	if err := store.syncWorkspaceRoot(ctx, workspace, manifest); err != nil {
+		step.fail(err.Error())
+		return err
+	}
+	rootDuration := step.elapsed()
+	step.succeed(workspaceRedisKey(workspace))
+
 	if err := store.audit(ctx, workspace, "import", map[string]any{
 		"savepoint":   initialSavepoint,
 		"files":       stats.FileCount,
@@ -181,6 +189,7 @@ func cmdImport(args []string) error {
 		{Label: "manifest", Value: formatStepDuration(manifestDuration)},
 		{Label: "blobs", Value: formatStepDuration(blobDuration)},
 		{Label: "metadata", Value: formatStepDuration(metadataDuration)},
+		{Label: "live root", Value: formatStepDuration(rootDuration)},
 		{Label: "next", Value: filepath.Base(os.Args[0]) + " workspace run " + workspace + " -- /bin/sh"},
 	})
 	return nil
@@ -189,19 +198,22 @@ func cmdImport(args []string) error {
 func prepareAFSImport(sourceDir, workspace string, cfg config, replaceExisting bool) (importStats, *migrationIgnore, time.Duration, error) {
 	reader := bufio.NewReader(os.Stdin)
 	interactive := isInteractiveTerminal()
+	exclusions := newAFSImportExclusions()
 
 	for {
-		ignorer, err := loadMigrationIgnore(sourceDir)
+		baseIgnorer, err := loadMigrationIgnore(sourceDir)
 		if err != nil {
 			return importStats{}, nil, 0, err
 		}
+		ignorer := applyAFSImportExclusions(baseIgnorer, exclusions)
 
 		step := startStep("Scanning source directory")
-		total, err := scanDirectory(sourceDir, ignorer)
+		scan, err := scanDirectoryReport(sourceDir, ignorer, afsImportReviewLargestLimit)
 		if err != nil {
 			step.fail(err.Error())
 			return importStats{}, nil, 0, err
 		}
+		total := scan.Stats
 		scanDuration := step.elapsed()
 		step.succeed(formatAFSImportSummary(total))
 
@@ -216,27 +228,69 @@ func prepareAFSImport(sourceDir, workspace string, cfg config, replaceExisting b
 			{Label: "scan", Value: formatAFSImportSummary(total)},
 			{Label: "estimate", Value: "~" + formatStepDuration(estimate)},
 		}
-		if ignorer != nil {
-			value := ignorer.path
-			if ignorer.legacy {
+		if baseIgnorer != nil {
+			value := baseIgnorer.path
+			if baseIgnorer.legacy {
 				value += " (legacy filename)"
 			}
 			rows = append(rows, boxRow{Label: "ignore", Value: value})
 		} else {
 			rows = append(rows, boxRow{Label: "ignore", Value: clr(ansiDim, "none")})
 		}
+		if !exclusions.empty() {
+			rows = append(rows, boxRow{Label: "exclude", Value: exclusions.preview(3)})
+		}
 		if replaceExisting {
 			rows = append(rows, boxRow{Label: "replace", Value: "existing workspace state will be removed"})
 		}
 		rows = append(rows,
 			boxRow{},
-			boxRow{Value: clr(ansiDim, "Tip: use .afsignore to skip caches, dependencies, logs, or build output before import.")},
+			boxRow{Value: clr(ansiDim, "Tip: review the largest items below, or edit .afsignore to make exclusions persistent.")},
 		)
+		if hasAFSImportReviewCandidates(scan) {
+			rows = append(rows, boxRow{})
+			if len(scan.LargestFiles) > 0 {
+				rows = append(rows, boxRow{Value: clr(ansiBold, "Largest files")})
+				for _, item := range scan.LargestFiles {
+					rows = append(rows, boxRow{
+						Value: fmt.Sprintf("%s · %s", formatBytes(item.Bytes), item.Path),
+					})
+				}
+			}
+			if len(scan.LargestDirs) > 0 {
+				if len(scan.LargestFiles) > 0 {
+					rows = append(rows, boxRow{})
+				}
+				rows = append(rows, boxRow{Value: clr(ansiBold, "Largest directories")})
+				for _, item := range scan.LargestDirs {
+					rows = append(rows, boxRow{
+						Value: fmt.Sprintf("%s · %d files · %s/", formatBytes(item.Bytes), item.Files, item.Path),
+					})
+				}
+			}
+		}
 		printBox(clr(ansiBold, "Import plan"), rows)
 
+		if hasAFSImportReviewCandidates(scan) {
+			reviewLarge, err := promptYesNo(reader, os.Stdout, "  Review largest files and directories?", false)
+			if err != nil {
+				return importStats{}, nil, 0, err
+			}
+			if reviewLarge {
+				changed, err := reviewAFSImportExclusions(reader, os.Stdout, sourceDir, scan, &exclusions)
+				if err != nil {
+					return importStats{}, nil, 0, err
+				}
+				if changed {
+					fmt.Println()
+					continue
+				}
+			}
+		}
+
 		editLabel := "  Create or edit .afsignore before importing?"
-		if ignorer != nil {
-			editLabel = fmt.Sprintf("  Edit %s before importing?", filepath.Base(ignorer.path))
+		if baseIgnorer != nil {
+			editLabel = fmt.Sprintf("  Edit %s before importing?", filepath.Base(baseIgnorer.path))
 		}
 		editIgnore, err := promptYesNo(reader, os.Stdout, editLabel, false)
 		if err != nil {
@@ -244,8 +298,8 @@ func prepareAFSImport(sourceDir, workspace string, cfg config, replaceExisting b
 		}
 		if editIgnore {
 			ignorePath := filepath.Join(sourceDir, afsIgnoreFilename)
-			if ignorer != nil && !ignorer.legacy {
-				ignorePath = ignorer.path
+			if baseIgnorer != nil && !baseIgnorer.legacy {
+				ignorePath = baseIgnorer.path
 			}
 			if err := ensureAFSIgnoreTemplate(ignorePath); err != nil {
 				return importStats{}, nil, 0, err
@@ -398,15 +452,16 @@ func afsBlobTotals(blobs map[string][]byte) (int, int64) {
 }
 
 func currentWorkspaceName(ctx context.Context, cfg config, store *afsStore) (string, error) {
-	if strings.TrimSpace(cfg.CurrentWorkspace) != "" {
-		exists, err := store.workspaceExists(ctx, cfg.CurrentWorkspace)
+	workspace := selectedWorkspaceName(cfg)
+	if workspace != "" {
+		exists, err := store.workspaceExists(ctx, workspace)
 		if err != nil {
 			return "", err
 		}
 		if exists {
-			return cfg.CurrentWorkspace, nil
+			return workspace, nil
 		}
-		return "", fmt.Errorf("current workspace %q does not exist; run '%s workspace use <workspace>' or pass a workspace explicitly", cfg.CurrentWorkspace, filepath.Base(os.Args[0]))
+		return "", fmt.Errorf("current workspace %q does not exist; run '%s workspace use <workspace>' or pass a workspace explicitly", workspace, filepath.Base(os.Args[0]))
 	}
 	return "", fmt.Errorf("workspace is required; no current workspace is selected\nRun '%s workspace use <workspace>' or pass a workspace explicitly", filepath.Base(os.Args[0]))
 }
@@ -416,6 +471,19 @@ func resolveWorkspaceName(ctx context.Context, cfg config, store *afsStore, requ
 		return requested, nil
 	}
 	return currentWorkspaceName(ctx, cfg, store)
+}
+
+func selectedWorkspaceName(cfg config) string {
+	if st, err := loadState(); err == nil {
+		backendName := strings.TrimSpace(st.MountBackend)
+		if backendName == "" {
+			backendName = mountBackendNone
+		}
+		if backendName != mountBackendNone && strings.TrimSpace(st.CurrentWorkspace) != "" {
+			return strings.TrimSpace(st.CurrentWorkspace)
+		}
+	}
+	return strings.TrimSpace(cfg.CurrentWorkspace)
 }
 
 func runAFSCommand(ctx context.Context, cfg config, store *afsStore, workspace string, childArgs []string, readonly bool) error {
@@ -494,10 +562,10 @@ func saveAFSWorkspace(ctx context.Context, cfg config, store *afsStore, workspac
 	workspaceInfo, localState, err := requireMaterializedWorkspace(ctx, store, cfg, workspace)
 	if err != nil {
 		if errors.Is(err, errAFSWorkspaceConflict) {
-			return false, fmt.Errorf("workspace %q moved since this tree was materialized; reopen it before creating a checkpoint", workspace)
+			return false, fmt.Errorf("%w: workspace %q moved since this tree was materialized; reopen it before creating a checkpoint", errAFSWorkspaceConflict, workspace)
 		}
 		if errors.Is(err, errAFSWorkspaceNotMaterialized) {
-			return false, fmt.Errorf("workspace %q has no working copy yet; run '%s workspace run %s -- /bin/sh' first", workspace, filepath.Base(os.Args[0]), workspace)
+			return false, fmt.Errorf("%w: workspace %q has no working copy yet; run '%s workspace run %s -- /bin/sh' first", errAFSWorkspaceNotMaterialized, workspace, filepath.Base(os.Args[0]), workspace)
 		}
 		return false, err
 	}
@@ -532,7 +600,7 @@ func saveAFSWorkspace(ctx context.Context, cfg config, store *afsStore, workspac
 	saved, err := saveAFSManifest(ctx, store, workspace, localState.HeadSavepoint, savepointID, localManifest, blobs, stats)
 	if err != nil {
 		if errors.Is(err, errAFSWorkspaceConflict) {
-			return false, fmt.Errorf("checkpoint conflict: workspace %q moved while saving; reopen it before retrying", workspace)
+			return false, fmt.Errorf("%w: checkpoint conflict: workspace %q moved while saving; reopen it before retrying", errAFSWorkspaceConflict, workspace)
 		}
 		return false, err
 	}
@@ -557,6 +625,71 @@ func saveAFSWorkspace(ctx context.Context, cfg config, store *afsStore, workspac
 		})
 	}
 	return true, nil
+}
+
+func saveAFSWorkspaceOrLiveRoot(ctx context.Context, cfg config, store *afsStore, workspace, savepointID string, printResult bool) (bool, error) {
+	if activeMountedLiveWorkspace(workspace) {
+		return saveLiveWorkspaceCheckpoint(ctx, store, workspace, savepointID, printResult)
+	}
+
+	saved, err := saveAFSWorkspace(ctx, cfg, store, workspace, savepointID, printResult)
+	if err == nil || !errors.Is(err, errAFSWorkspaceNotMaterialized) {
+		return saved, err
+	}
+
+	return saveLiveWorkspaceCheckpoint(ctx, store, workspace, savepointID, printResult)
+}
+
+func saveLiveWorkspaceCheckpoint(ctx context.Context, store *afsStore, workspace, savepointID string, printResult bool) (bool, error) {
+	workspaceInfo, metaErr := store.getWorkspaceMeta(ctx, workspace)
+	if metaErr != nil {
+		return false, metaErr
+	}
+	if _, _, _, err := store.ensureWorkspaceRoot(ctx, workspace); err != nil {
+		return false, err
+	}
+	saved, err := saveWorkspaceRootCheckpoint(ctx, store, workspace, workspaceInfo.HeadSavepoint, savepointID)
+	if err != nil {
+		if errors.Is(err, errAFSWorkspaceConflict) {
+			return false, fmt.Errorf("checkpoint conflict: workspace %q moved while saving; reopen it before retrying", workspace)
+		}
+		return false, err
+	}
+	if !saved {
+		if printResult {
+			fmt.Println("No changes to save")
+		}
+		return false, nil
+	}
+
+	if printResult {
+		printBox(clr(ansiBGreen, "●")+" "+clr(ansiBold, "save complete"), []boxRow{
+			{Label: "workspace", Value: workspace},
+			{Label: "savepoint", Value: savepointID},
+			{Label: "source", Value: "live workspace"},
+		})
+	}
+	return true, nil
+}
+
+func activeMountedLiveWorkspace(workspace string) bool {
+	st, err := loadState()
+	if err != nil {
+		return false
+	}
+	if strings.TrimSpace(st.CurrentWorkspace) != workspace {
+		return false
+	}
+
+	backendName := strings.TrimSpace(st.MountBackend)
+	if backendName == "" {
+		backendName = mountBackendNone
+	}
+	if backendName == mountBackendNone {
+		return false
+	}
+
+	return strings.TrimSpace(st.RedisKey) == workspaceRedisKey(workspace)
 }
 
 func saveAFSManifest(ctx context.Context, store *afsStore, workspace, expectedHead, savepointID string, localManifest manifest, blobs map[string][]byte, stats manifestStats) (bool, error) {

--- a/cli/afs_commands_test.go
+++ b/cli/afs_commands_test.go
@@ -143,6 +143,55 @@ func TestCurrentWorkspaceNameUsesConfiguredCurrentWorkspace(t *testing.T) {
 	}
 }
 
+func TestCurrentWorkspaceNamePrefersActiveMountedWorkspace(t *testing.T) {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", homeDir); err != nil {
+		t.Fatalf("Setenv(HOME) returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", origHome)
+	})
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() {
+		_ = rdb.Close()
+	})
+
+	cfg := defaultConfig()
+	cfg.WorkRoot = t.TempDir()
+	cfg.CurrentWorkspace = "alpha"
+	store := newAFSStore(rdb)
+
+	ctx := context.Background()
+	if err := createEmptyWorkspace(ctx, cfg, store, "alpha"); err != nil {
+		t.Fatalf("createEmptyWorkspace(alpha) returned error: %v", err)
+	}
+	if err := createEmptyWorkspace(ctx, cfg, store, "beta"); err != nil {
+		t.Fatalf("createEmptyWorkspace(beta) returned error: %v", err)
+	}
+
+	if err := saveState(state{
+		StartedAt:        time.Now().UTC(),
+		CurrentWorkspace: "beta",
+		MountBackend:     mountBackendNFS,
+		RedisKey:         workspaceRedisKey("beta"),
+	}); err != nil {
+		t.Fatalf("saveState() returned error: %v", err)
+	}
+
+	got, err := currentWorkspaceName(ctx, cfg, store)
+	if err != nil {
+		t.Fatalf("currentWorkspaceName() returned error: %v", err)
+	}
+	if got != "beta" {
+		t.Fatalf("currentWorkspaceName() = %q, want %q", got, "beta")
+	}
+}
+
 func TestCurrentWorkspaceNameErrorsWhenConfiguredCurrentWorkspaceMissing(t *testing.T) {
 	t.Helper()
 

--- a/cli/afs_import_review.go
+++ b/cli/afs_import_review.go
@@ -1,0 +1,349 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const afsImportReviewLargestLimit = 5
+
+type afsImportExclusions struct {
+	files map[string]struct{}
+	dirs  map[string]struct{}
+}
+
+type afsImportReviewChoice struct {
+	ID   string
+	Item importScanEntry
+}
+
+func newAFSImportExclusions() afsImportExclusions {
+	return afsImportExclusions{
+		files: make(map[string]struct{}),
+		dirs:  make(map[string]struct{}),
+	}
+}
+
+func (e afsImportExclusions) empty() bool {
+	return len(e.files) == 0 && len(e.dirs) == 0
+}
+
+func (e afsImportExclusions) count() int {
+	return len(e.files) + len(e.dirs)
+}
+
+func (e afsImportExclusions) preview(limit int) string {
+	if e.empty() {
+		return clr(ansiDim, "none")
+	}
+
+	items := make([]string, 0, e.count())
+	for dir := range e.dirs {
+		items = append(items, dir+"/")
+	}
+	for file := range e.files {
+		items = append(items, file)
+	}
+	sort.Strings(items)
+
+	if limit > 0 && len(items) > limit {
+		hidden := len(items) - limit
+		return strings.Join(items[:limit], ", ") + fmt.Sprintf(" +%d more", hidden)
+	}
+	return strings.Join(items, ", ")
+}
+
+func (e *afsImportExclusions) clear() bool {
+	if e == nil || e.empty() {
+		return false
+	}
+	e.files = make(map[string]struct{})
+	e.dirs = make(map[string]struct{})
+	return true
+}
+
+func (e *afsImportExclusions) add(item importScanEntry) bool {
+	if e == nil {
+		return false
+	}
+	if e.files == nil {
+		e.files = make(map[string]struct{})
+	}
+	if e.dirs == nil {
+		e.dirs = make(map[string]struct{})
+	}
+
+	switch item.Kind {
+	case "dir":
+		if e.containsPath(item.Path) {
+			return false
+		}
+		for dir := range e.dirs {
+			if dir == item.Path || strings.HasPrefix(dir, item.Path+"/") {
+				delete(e.dirs, dir)
+			}
+		}
+		for file := range e.files {
+			if file == item.Path || strings.HasPrefix(file, item.Path+"/") {
+				delete(e.files, file)
+			}
+		}
+		e.dirs[item.Path] = struct{}{}
+		return true
+	default:
+		if e.containsPath(item.Path) {
+			return false
+		}
+		e.files[item.Path] = struct{}{}
+		return true
+	}
+}
+
+func (e afsImportExclusions) containsPath(path string) bool {
+	if _, ok := e.files[path]; ok {
+		return true
+	}
+	for dir := range e.dirs {
+		if path == dir || strings.HasPrefix(path, dir+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func applyAFSImportExclusions(base *migrationIgnore, exclusions afsImportExclusions) *migrationIgnore {
+	if base == nil && exclusions.empty() {
+		return nil
+	}
+
+	overlay := &migrationIgnore{}
+	if base != nil {
+		*overlay = *base
+	}
+	overlay.tempFiles = copyImportSelectionSet(exclusions.files)
+	overlay.tempDirs = copyImportSelectionSet(exclusions.dirs)
+	return overlay
+}
+
+func copyImportSelectionSet(src map[string]struct{}) map[string]struct{} {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make(map[string]struct{}, len(src))
+	for key := range src {
+		dst[key] = struct{}{}
+	}
+	return dst
+}
+
+func hasAFSImportReviewCandidates(scan importScanReport) bool {
+	return len(scan.LargestFiles) > 0 || len(scan.LargestDirs) > 0
+}
+
+func reviewAFSImportExclusions(r *bufio.Reader, out io.Writer, sourceDir string, scan importScanReport, exclusions *afsImportExclusions) (bool, error) {
+	choices, rows := buildAFSImportReviewChoices(scan)
+	if len(choices) == 0 {
+		return false, nil
+	}
+
+	for {
+		printBox(clr(ansiBold, "Largest items"), rows)
+		fmt.Fprintln(out, "  Enter numbers or relative paths to exclude for this import.")
+		fmt.Fprintln(out, "  Use commas for multiple entries, `reset` to clear temporary exclusions, or press Enter to go back.")
+
+		input, err := promptString(r, out, "  Exclude", "")
+		if err != nil {
+			return false, err
+		}
+		input = strings.TrimSpace(input)
+		if input == "" {
+			return false, nil
+		}
+		if strings.EqualFold(input, "reset") {
+			if exclusions.clear() {
+				fmt.Fprintln(out)
+				fmt.Fprintln(out, "  Cleared temporary exclusions.")
+				fmt.Fprintln(out)
+				return true, nil
+			}
+			fmt.Fprintln(out)
+			fmt.Fprintln(out, "  No temporary exclusions to clear.")
+			fmt.Fprintln(out)
+			continue
+		}
+
+		added, err := applyAFSImportReviewInput(sourceDir, input, choices, exclusions)
+		if err != nil {
+			fmt.Fprintln(out)
+			fmt.Fprintf(out, "  %s\n\n", err)
+			continue
+		}
+
+		fmt.Fprintln(out)
+		if added == 1 {
+			fmt.Fprintln(out, "  Added 1 temporary exclusion. Re-scanning import plan...")
+		} else {
+			fmt.Fprintf(out, "  Added %d temporary exclusions. Re-scanning import plan...\n", added)
+		}
+		fmt.Fprintln(out)
+		return true, nil
+	}
+}
+
+func buildAFSImportReviewChoices(scan importScanReport) ([]afsImportReviewChoice, []boxRow) {
+	choices := make([]afsImportReviewChoice, 0, len(scan.LargestFiles)+len(scan.LargestDirs))
+	rows := make([]boxRow, 0, len(scan.LargestFiles)+len(scan.LargestDirs)+4)
+	nextID := 1
+
+	if len(scan.LargestFiles) > 0 {
+		rows = append(rows, boxRow{Value: clr(ansiBold, "Largest files")})
+		for _, item := range scan.LargestFiles {
+			choice := afsImportReviewChoice{
+				ID:   strconv.Itoa(nextID),
+				Item: item,
+			}
+			choices = append(choices, choice)
+			rows = append(rows, boxRow{
+				Label: choice.ID,
+				Value: formatAFSImportReviewChoice(choice),
+			})
+			nextID++
+		}
+	}
+
+	if len(scan.LargestDirs) > 0 {
+		if len(rows) > 0 {
+			rows = append(rows, boxRow{})
+		}
+		rows = append(rows, boxRow{Value: clr(ansiBold, "Largest directories")})
+		for _, item := range scan.LargestDirs {
+			choice := afsImportReviewChoice{
+				ID:   strconv.Itoa(nextID),
+				Item: item,
+			}
+			choices = append(choices, choice)
+			rows = append(rows, boxRow{
+				Label: choice.ID,
+				Value: formatAFSImportReviewChoice(choice),
+			})
+			nextID++
+		}
+	}
+
+	return choices, rows
+}
+
+func formatAFSImportReviewChoice(choice afsImportReviewChoice) string {
+	if choice.Item.Kind == "dir" {
+		return fmt.Sprintf("%s · dir · %d files · %s/", formatBytes(choice.Item.Bytes), choice.Item.Files, choice.Item.Path)
+	}
+	return fmt.Sprintf("%s · file · %s", formatBytes(choice.Item.Bytes), choice.Item.Path)
+}
+
+func applyAFSImportReviewInput(sourceDir, input string, choices []afsImportReviewChoice, exclusions *afsImportExclusions) (int, error) {
+	choiceMap := make(map[string]importScanEntry, len(choices))
+	for _, choice := range choices {
+		choiceMap[choice.ID] = choice.Item
+	}
+
+	var added int
+	for _, token := range splitAFSImportReviewInput(input) {
+		item, err := resolveAFSImportReviewToken(sourceDir, token, choiceMap)
+		if err != nil {
+			return 0, err
+		}
+		if exclusions.add(item) {
+			added++
+		}
+	}
+	if added == 0 {
+		return 0, fmt.Errorf("those selections are already excluded for this import")
+	}
+	return added, nil
+}
+
+func splitAFSImportReviewInput(input string) []string {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return nil
+	}
+	if strings.Contains(trimmed, ",") {
+		raw := strings.Split(trimmed, ",")
+		out := make([]string, 0, len(raw))
+		for _, token := range raw {
+			token = strings.TrimSpace(token)
+			if token != "" {
+				out = append(out, token)
+			}
+		}
+		return out
+	}
+
+	fields := strings.Fields(trimmed)
+	if len(fields) > 1 {
+		numeric := true
+		for _, field := range fields {
+			if _, err := strconv.Atoi(field); err != nil {
+				numeric = false
+				break
+			}
+		}
+		if numeric {
+			return fields
+		}
+	}
+
+	return []string{trimmed}
+}
+
+func resolveAFSImportReviewToken(sourceDir, token string, choiceMap map[string]importScanEntry) (importScanEntry, error) {
+	token = strings.Trim(strings.TrimSpace(token), `"'`)
+	if token == "" {
+		return importScanEntry{}, fmt.Errorf("choose a numbered item or a path inside %s", sourceDir)
+	}
+	if item, ok := choiceMap[token]; ok {
+		return item, nil
+	}
+
+	trimmed := strings.TrimRight(token, "/")
+	if trimmed == "" || trimmed == "." {
+		return importScanEntry{}, fmt.Errorf("choose a file or directory inside %s", sourceDir)
+	}
+
+	fullPath := trimmed
+	if !filepath.IsAbs(fullPath) {
+		fullPath = filepath.Join(sourceDir, filepath.FromSlash(trimmed))
+	}
+	fullPath = filepath.Clean(fullPath)
+
+	rel, err := filepath.Rel(sourceDir, fullPath)
+	if err != nil {
+		return importScanEntry{}, err
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return importScanEntry{}, fmt.Errorf("%s is outside the import root", token)
+	}
+
+	info, err := os.Lstat(fullPath)
+	if err != nil {
+		return importScanEntry{}, err
+	}
+
+	item := importScanEntry{
+		Path: filepath.ToSlash(rel),
+	}
+	if info.IsDir() {
+		item.Kind = "dir"
+	} else {
+		item.Kind = "file"
+		item.Bytes = info.Size()
+		item.Files = 1
+	}
+	return item, nil
+}

--- a/cli/afs_import_review_test.go
+++ b/cli/afs_import_review_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestScanDirectoryReportTracksLargestFilesAndDirs(t *testing.T) {
+	sourceDir := t.TempDir()
+
+	writeTestFile(t, filepath.Join(sourceDir, "root.txt"), "12345")
+	writeTestFile(t, filepath.Join(sourceDir, "cache", "blob.bin"), "1234567890")
+	writeTestFile(t, filepath.Join(sourceDir, "vendor", "pkg.tar"), "1234567")
+	writeTestFile(t, filepath.Join(sourceDir, "vendor", "README.md"), "12")
+	writeTestFile(t, filepath.Join(sourceDir, "docs", "guide.md"), "1234")
+
+	report, err := scanDirectoryReport(sourceDir, nil, 3)
+	if err != nil {
+		t.Fatalf("scanDirectoryReport() returned error: %v", err)
+	}
+
+	if report.Stats.Files != 5 {
+		t.Fatalf("Files = %d, want 5", report.Stats.Files)
+	}
+	if report.Stats.Dirs != 3 {
+		t.Fatalf("Dirs = %d, want 3", report.Stats.Dirs)
+	}
+	if report.Stats.Bytes != 28 {
+		t.Fatalf("Bytes = %d, want 28", report.Stats.Bytes)
+	}
+
+	if len(report.LargestFiles) != 3 {
+		t.Fatalf("len(LargestFiles) = %d, want 3", len(report.LargestFiles))
+	}
+	if report.LargestFiles[0].Path != "cache/blob.bin" || report.LargestFiles[0].Bytes != 10 {
+		t.Fatalf("LargestFiles[0] = %+v, want cache/blob.bin (10 bytes)", report.LargestFiles[0])
+	}
+	if report.LargestFiles[1].Path != "vendor/pkg.tar" || report.LargestFiles[1].Bytes != 7 {
+		t.Fatalf("LargestFiles[1] = %+v, want vendor/pkg.tar (7 bytes)", report.LargestFiles[1])
+	}
+	if report.LargestFiles[2].Path != "root.txt" || report.LargestFiles[2].Bytes != 5 {
+		t.Fatalf("LargestFiles[2] = %+v, want root.txt (5 bytes)", report.LargestFiles[2])
+	}
+
+	if len(report.LargestDirs) != 3 {
+		t.Fatalf("len(LargestDirs) = %d, want 3", len(report.LargestDirs))
+	}
+	if report.LargestDirs[0].Path != "cache" || report.LargestDirs[0].Bytes != 10 || report.LargestDirs[0].Files != 1 {
+		t.Fatalf("LargestDirs[0] = %+v, want cache (10 bytes, 1 file)", report.LargestDirs[0])
+	}
+	if report.LargestDirs[1].Path != "vendor" || report.LargestDirs[1].Bytes != 9 || report.LargestDirs[1].Files != 2 {
+		t.Fatalf("LargestDirs[1] = %+v, want vendor (9 bytes, 2 files)", report.LargestDirs[1])
+	}
+	if report.LargestDirs[2].Path != "docs" || report.LargestDirs[2].Bytes != 4 || report.LargestDirs[2].Files != 1 {
+		t.Fatalf("LargestDirs[2] = %+v, want docs (4 bytes, 1 file)", report.LargestDirs[2])
+	}
+}
+
+func TestApplyAFSImportExclusionsOverridesExistingIgnoreBehavior(t *testing.T) {
+	sourceDir := t.TempDir()
+
+	writeTestFile(t, filepath.Join(sourceDir, ".afsignore"), "*.log\n!logs/keep.log\n")
+	writeTestFile(t, filepath.Join(sourceDir, "logs", "keep.log"), "keep")
+	writeTestFile(t, filepath.Join(sourceDir, "build", "artifact.bin"), "artifact")
+
+	baseIgnorer, err := loadMigrationIgnore(sourceDir)
+	if err != nil {
+		t.Fatalf("loadMigrationIgnore() returned error: %v", err)
+	}
+
+	exclusions := newAFSImportExclusions()
+	if !exclusions.add(importScanEntry{Kind: "file", Path: "logs/keep.log"}) {
+		t.Fatal("expected keep.log to be added as a temporary exclusion")
+	}
+	if !exclusions.add(importScanEntry{Kind: "dir", Path: "build"}) {
+		t.Fatal("expected build/ to be added as a temporary exclusion")
+	}
+
+	ignorer := applyAFSImportExclusions(baseIgnorer, exclusions)
+
+	keepEntry := dirEntryForTest(t, filepath.Join(sourceDir, "logs"), "keep.log")
+	keepPath := filepath.Join(sourceDir, "logs", "keep.log")
+	matches, err := ignorer.matches(sourceDir, keepPath, keepEntry)
+	if err != nil {
+		t.Fatalf("ignorer.matches(keep.log) returned error: %v", err)
+	}
+	if !matches {
+		t.Fatal("expected temporary file exclusion to override the allowlist in .afsignore")
+	}
+
+	buildDirEntry := dirEntryForTest(t, sourceDir, "build")
+	buildPath := filepath.Join(sourceDir, "build")
+	matches, err = ignorer.matches(sourceDir, buildPath, buildDirEntry)
+	if err != nil {
+		t.Fatalf("ignorer.matches(build/) returned error: %v", err)
+	}
+	if !matches {
+		t.Fatal("expected build/ directory to be excluded")
+	}
+
+	artifactEntry := dirEntryForTest(t, filepath.Join(sourceDir, "build"), "artifact.bin")
+	artifactPath := filepath.Join(sourceDir, "build", "artifact.bin")
+	matches, err = ignorer.matches(sourceDir, artifactPath, artifactEntry)
+	if err != nil {
+		t.Fatalf("ignorer.matches(build/artifact.bin) returned error: %v", err)
+	}
+	if !matches {
+		t.Fatal("expected children of a temporary directory exclusion to be excluded")
+	}
+}
+
+func dirEntryForTest(t *testing.T, dir, base string) os.DirEntry {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(%s) returned error: %v", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.Name() == base {
+			return entry
+		}
+	}
+	t.Fatalf("entry %s not found under %s", base, dir)
+	return nil
+}

--- a/cli/afs_import_scan.go
+++ b/cli/afs_import_scan.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"os"
+	pathpkg "path"
+	"path/filepath"
+	"sort"
+)
+
+type importScanEntry struct {
+	Kind  string
+	Path  string
+	Bytes int64
+	Files int
+}
+
+type importScanReport struct {
+	Stats        importStats
+	LargestFiles []importScanEntry
+	LargestDirs  []importScanEntry
+}
+
+func scanDirectoryReport(source string, ignorer *migrationIgnore, limit int) (importScanReport, error) {
+	var report importScanReport
+	dirBytes := make(map[string]int64)
+	dirFiles := make(map[string]int)
+
+	err := filepath.WalkDir(source, func(path string, d os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if path == source {
+			return nil
+		}
+
+		skip, err := ignorer.matches(source, path, d)
+		if err != nil {
+			return err
+		}
+		if skip {
+			report.Stats.Ignored++
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+
+		switch {
+		case d.Type()&os.ModeSymlink != 0:
+			report.Stats.Symlinks++
+		case d.IsDir():
+			report.Stats.Dirs++
+		default:
+			rel, err := relativeImportPath(source, path)
+			if err != nil {
+				return err
+			}
+
+			size := info.Size()
+			report.Stats.Files++
+			report.Stats.Bytes += size
+
+			if limit > 0 {
+				report.LargestFiles = insertTopImportEntry(report.LargestFiles, importScanEntry{
+					Kind:  "file",
+					Path:  rel,
+					Bytes: size,
+					Files: 1,
+				}, limit)
+				for dir := pathpkg.Dir(rel); dir != "." && dir != "/"; dir = pathpkg.Dir(dir) {
+					dirBytes[dir] += size
+					dirFiles[dir]++
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return report, err
+	}
+
+	if limit > 0 {
+		for dir, size := range dirBytes {
+			if size <= 0 {
+				continue
+			}
+			report.LargestDirs = insertTopImportEntry(report.LargestDirs, importScanEntry{
+				Kind:  "dir",
+				Path:  dir,
+				Bytes: size,
+				Files: dirFiles[dir],
+			}, limit)
+		}
+	}
+
+	return report, nil
+}
+
+func insertTopImportEntry(entries []importScanEntry, candidate importScanEntry, limit int) []importScanEntry {
+	if limit <= 0 {
+		return entries
+	}
+	entries = append(entries, candidate)
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Bytes == entries[j].Bytes {
+			if entries[i].Files == entries[j].Files {
+				return entries[i].Path < entries[j].Path
+			}
+			return entries[i].Files > entries[j].Files
+		}
+		return entries[i].Bytes > entries[j].Bytes
+	})
+	if len(entries) > limit {
+		entries = entries[:limit]
+	}
+	return entries
+}

--- a/cli/afs_session_reset.go
+++ b/cli/afs_session_reset.go
@@ -17,8 +17,10 @@ func resetAFSWorkspaceHead(ctx context.Context, cfg config, store *afsStore, ser
 	result := afsWorkspaceResetResult{
 		treePath: afsWorkspaceTreePath(cfg, workspace),
 	}
+	shouldMaterializeLocalTree := false
 
 	if _, err := os.Stat(result.treePath); err == nil {
+		shouldMaterializeLocalTree = true
 		archivePath, err := archiveLocalTree(cfg, workspace)
 		if err != nil {
 			return result, err
@@ -26,6 +28,13 @@ func resetAFSWorkspaceHead(ctx context.Context, cfg config, store *afsStore, ser
 		result.archivePath = archivePath
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return result, err
+	}
+	if !shouldMaterializeLocalTree {
+		if _, err := os.Stat(afsWorkspaceStatePath(cfg, workspace)); err == nil {
+			shouldMaterializeLocalTree = true
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return result, err
+		}
 	}
 
 	if err := service.RestoreCheckpoint(ctx, workspace, savepoint); err != nil {
@@ -35,8 +44,10 @@ func resetAFSWorkspaceHead(ctx context.Context, cfg config, store *afsStore, ser
 		return result, err
 	}
 
-	if err := materializeWorkspace(ctx, store, cfg, workspace); err != nil {
-		return result, err
+	if shouldMaterializeLocalTree {
+		if err := materializeWorkspace(ctx, store, cfg, workspace); err != nil {
+			return result, err
+		}
 	}
 
 	return result, nil

--- a/cli/afs_store.go
+++ b/cli/afs_store.go
@@ -86,3 +86,15 @@ func (s *afsStore) audit(ctx context.Context, workspace, op string, extra map[st
 func (s *afsStore) listAudit(ctx context.Context, workspace string, limit int64) ([]auditRecord, error) {
 	return s.cp.ListAudit(ctx, workspace, limit)
 }
+
+func (s *afsStore) ensureWorkspaceRoot(ctx context.Context, workspace string) (string, string, bool, error) {
+	return controlplane.EnsureWorkspaceRoot(ctx, s.cp, workspace)
+}
+
+func (s *afsStore) syncWorkspaceRoot(ctx context.Context, workspace string, m manifest) error {
+	return controlplane.SyncWorkspaceRoot(ctx, s.cp, workspace, m)
+}
+
+func workspaceRedisKey(workspace string) string {
+	return controlplane.WorkspaceFSKey(workspace)
+}

--- a/cli/afs_surface_test.go
+++ b/cli/afs_surface_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/alicebob/miniredis/v2"
 )
 
 func TestConfigPathDefaultsToAFSConfig(t *testing.T) {
@@ -36,6 +34,22 @@ func TestCompactDisplayPathUsesParentAndFilename(t *testing.T) {
 
 	if got := compactDisplayPath("afs.config.json"); got != "afs.config.json" {
 		t.Fatalf("compactDisplayPath(single file) = %q, want %q", got, "afs.config.json")
+	}
+}
+
+func TestFormatDisplayTimestampUsesReadableLocalTime(t *testing.T) {
+	t.Helper()
+
+	origLocal := time.Local
+	time.Local = time.FixedZone("MST", -7*60*60)
+	t.Cleanup(func() {
+		time.Local = origLocal
+	})
+
+	got := formatDisplayTimestamp("2026-04-06T22:52:53Z")
+	want := "Apr 6, 2026 3:52 PM"
+	if got != want {
+		t.Fatalf("formatDisplayTimestamp() = %q, want %q", got, want)
 	}
 }
 
@@ -304,7 +318,7 @@ func TestCmdUpShowsStatusWhenAlreadyRunning(t *testing.T) {
 	}
 }
 
-func TestCmdDownContinuesWhenMountedWorkspaceCannotBeSaved(t *testing.T) {
+func TestCmdDownStopsWithoutSavingMountedWorkspace(t *testing.T) {
 	t.Helper()
 
 	homeDir := t.TempDir()
@@ -316,18 +330,22 @@ func TestCmdDownContinuesWhenMountedWorkspaceCannotBeSaved(t *testing.T) {
 		_ = os.Setenv("HOME", origHome)
 	})
 
-	mr := miniredis.RunT(t)
+	mountpoint := filepath.Join(t.TempDir(), "mount")
+	if err := os.MkdirAll(mountpoint, 0o755); err != nil {
+		t.Fatalf("MkdirAll(mountpoint) returned error: %v", err)
+	}
 
 	st := state{
 		StartedAt:            time.Now().UTC(),
 		ManageRedis:          false,
-		RedisAddr:            mr.Addr(),
+		RedisAddr:            "127.0.0.1:65535",
 		RedisDB:              0,
 		CurrentWorkspace:     "demo",
 		MountedHeadSavepoint: "initial",
 		MountBackend:         mountBackendFuse,
-		Mountpoint:           filepath.Join(t.TempDir(), "mount"),
-		RedisKey:             "afs.mount.demo",
+		Mountpoint:           mountpoint,
+		CreatedMountpoint:    true,
+		RedisKey:             workspaceRedisKey("demo"),
 	}
 	if err := saveState(st); err != nil {
 		t.Fatalf("saveState() returned error: %v", err)
@@ -338,11 +356,14 @@ func TestCmdDownContinuesWhenMountedWorkspaceCannotBeSaved(t *testing.T) {
 		t.Fatalf("cmdDown() returned error: %v", err)
 	}
 
-	if !strings.Contains(out, "mounted changes for demo were not saved") {
-		t.Fatalf("cmdDown() output = %q, want unsaved changes warning", out)
+	if strings.Contains(out, "Saving mounted workspace") {
+		t.Fatalf("cmdDown() output = %q, want no mounted workspace save step", out)
 	}
 	if !strings.Contains(out, "afs stopped") {
 		t.Fatalf("cmdDown() output = %q, want stopped message", out)
+	}
+	if _, err := os.Stat(mountpoint); !os.IsNotExist(err) {
+		t.Fatalf("mountpoint should be removed after cmdDown(), stat err = %v", err)
 	}
 	if _, err := os.Stat(statePath()); !os.IsNotExist(err) {
 		t.Fatalf("statePath() should be removed after cmdDown(), stat err = %v", err)

--- a/cli/cmd/redis-qmd/main.go
+++ b/cli/cmd/redis-qmd/main.go
@@ -4,126 +4,240 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
-	"github.com/redis/go-redis/v9"
+	"github.com/rowantrollope/agent-filesystem/cli/internal/controlplane"
 	"github.com/rowantrollope/agent-filesystem/cli/qmd"
 )
 
+type optionalString struct {
+	value string
+	set   bool
+}
+
+func (o *optionalString) String() string { return o.value }
+
+func (o *optionalString) Set(v string) error {
+	o.value = v
+	o.set = true
+	return nil
+}
+
+type optionalInt struct {
+	value int
+	set   bool
+}
+
+func (o *optionalInt) String() string {
+	if !o.set {
+		return ""
+	}
+	return fmt.Sprintf("%d", o.value)
+}
+
+func (o *optionalInt) Set(v string) error {
+	var parsed int
+	if _, err := fmt.Sscanf(strings.TrimSpace(v), "%d", &parsed); err != nil {
+		return err
+	}
+	o.value = parsed
+	o.set = true
+	return nil
+}
+
+type cliOptions struct {
+	redisConfig controlplane.Config
+	key         string
+	index       string
+}
+
 func main() {
-	addr := flag.String("addr", "127.0.0.1:6379", "Redis host:port")
-	db := flag.Int("db", 0, "Redis DB")
-	key := flag.String("key", "", "agent-filesystem key name (required)")
-	index := flag.String("index", "", "RediSearch index name (default: afs_idx:{<key>})")
-	flag.Parse()
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
 
-	if *key == "" {
-		fmt.Fprintln(os.Stderr, "error: --key is required")
-		flag.Usage()
-		os.Exit(1)
+func run(args []string, stdout, stderr io.Writer) int {
+	opts, cmdArgs, err := parseCLI(args)
+	if err != nil {
+		fmt.Fprintln(stderr, "error:", err)
+		printUsage(stderr)
+		return 1
+	}
+	if len(cmdArgs) == 0 {
+		printUsage(stderr)
+		return 1
 	}
 
-	args := flag.Args()
-	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: redis-qmd --key <key> [flags] <command> [args...]")
-		fmt.Fprintln(os.Stderr, "commands: doctor, index <create|rebuild|info>, search <text>, query <dsl>")
-		os.Exit(1)
-	}
-
-	rdb := redis.NewClient(&redis.Options{
-		Addr: *addr,
-		DB:   *db,
-	})
+	rdb := controlplane.NewRedisClient(opts.redisConfig, 8)
 	defer rdb.Close()
 
-	client := qmd.NewClient(rdb, *key, *index)
+	client := qmd.NewClient(rdb, opts.key, opts.index)
 	ctx := context.Background()
 
-	cmd := args[0]
+	cmd := cmdArgs[0]
 	switch cmd {
 	case "doctor":
 		checks, err := client.Doctor(ctx)
 		for _, c := range checks {
-			fmt.Println(c)
+			fmt.Fprintln(stdout, c)
 		}
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "error:", err)
-			os.Exit(1)
+			fmt.Fprintln(stderr, "error:", err)
+			return 1
 		}
 
 	case "index":
-		if len(args) < 2 {
-			fmt.Fprintln(os.Stderr, "usage: index <create|rebuild|info>")
-			os.Exit(1)
+		if len(cmdArgs) < 2 {
+			fmt.Fprintln(stderr, "usage: index <create|rebuild|info>")
+			return 1
 		}
-		switch args[1] {
+		switch cmdArgs[1] {
 		case "create":
 			if err := client.CreateIndex(ctx); err != nil {
-				fmt.Fprintln(os.Stderr, "error:", err)
-				os.Exit(1)
+				fmt.Fprintln(stderr, "error:", err)
+				return 1
 			}
-			fmt.Println("index created:", client.IndexName())
+			fmt.Fprintln(stdout, "index created:", client.IndexName())
 		case "rebuild":
 			if err := client.RebuildIndex(ctx); err != nil {
-				fmt.Fprintln(os.Stderr, "error:", err)
-				os.Exit(1)
+				fmt.Fprintln(stderr, "error:", err)
+				return 1
 			}
-			fmt.Println("index rebuilt:", client.IndexName())
+			fmt.Fprintln(stdout, "index rebuilt:", client.IndexName())
 		case "info":
 			info, err := client.IndexInfo(ctx)
 			if err != nil {
-				fmt.Fprintln(os.Stderr, "error:", err)
-				os.Exit(1)
+				fmt.Fprintln(stderr, "error:", err)
+				return 1
 			}
 			for k, v := range info {
-				fmt.Printf("%s: %s\n", k, v)
+				fmt.Fprintf(stdout, "%s: %s\n", k, v)
 			}
 		default:
-			fmt.Fprintln(os.Stderr, "unknown index subcommand:", args[1])
-			os.Exit(1)
+			fmt.Fprintln(stderr, "unknown index subcommand:", cmdArgs[1])
+			return 1
 		}
 
 	case "search":
-		if len(args) < 2 {
-			fmt.Fprintln(os.Stderr, "usage: search <text>")
-			os.Exit(1)
+		if len(cmdArgs) < 2 {
+			fmt.Fprintln(stderr, "usage: search <text>")
+			return 1
 		}
-		text := strings.Join(args[1:], " ")
+		text := strings.Join(cmdArgs[1:], " ")
 		ftQuery := qmd.BuildSimpleSearchQuery(text)
 		total, hits, err := client.Search(ctx, ftQuery, qmd.QueryOptions{Limit: 20})
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "error:", err)
-			os.Exit(1)
+			fmt.Fprintln(stderr, "error:", err)
+			return 1
 		}
-		fmt.Printf("total: %d\n", total)
+		fmt.Fprintf(stdout, "total: %d\n", total)
 		for _, h := range hits {
-			fmt.Printf("%.4f  %s  (%s, %d bytes)\n", h.Score, h.Path, h.Type, h.Size)
+			fmt.Fprintf(stdout, "%.4f  %s  (%s, %d bytes)\n", h.Score, h.Path, h.Type, h.Size)
 		}
 
 	case "query":
-		if len(args) < 2 {
-			fmt.Fprintln(os.Stderr, "usage: query <dsl>")
-			os.Exit(1)
+		if len(cmdArgs) < 2 {
+			fmt.Fprintln(stderr, "usage: query <dsl>")
+			return 1
 		}
-		dslInput := strings.Join(args[1:], " ")
+		dslInput := strings.Join(cmdArgs[1:], " ")
 		parsed, err := qmd.ParseDSL(dslInput)
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "error parsing query:", err)
-			os.Exit(1)
+			fmt.Fprintln(stderr, "error parsing query:", err)
+			return 1
 		}
 		total, hits, err := client.SearchParsed(ctx, parsed, qmd.QueryOptions{Limit: 20})
 		if err != nil {
-			fmt.Fprintln(os.Stderr, "error:", err)
-			os.Exit(1)
+			fmt.Fprintln(stderr, "error:", err)
+			return 1
 		}
-		fmt.Printf("total: %d\n", total)
+		fmt.Fprintf(stdout, "total: %d\n", total)
 		for _, h := range hits {
-			fmt.Printf("%.4f  %s  (%s, %d bytes)\n", h.Score, h.Path, h.Type, h.Size)
+			fmt.Fprintf(stdout, "%.4f  %s  (%s, %d bytes)\n", h.Score, h.Path, h.Type, h.Size)
 		}
 
 	default:
-		fmt.Fprintln(os.Stderr, "unknown command:", cmd)
-		os.Exit(1)
+		fmt.Fprintln(stderr, "unknown command:", cmd)
+		return 1
+	}
+
+	return 0
+}
+
+func parseCLI(args []string) (cliOptions, []string, error) {
+	var opts cliOptions
+
+	fs := flag.NewFlagSet("redis-qmd", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+
+	var configPath string
+	var addr optionalString
+	var db optionalInt
+	var key optionalString
+	var index optionalString
+
+	fs.StringVar(&configPath, "config", "", "path to afs.config.json")
+	fs.Var(&addr, "addr", "Redis host:port (default: afs.config.json redisAddr, else 127.0.0.1:6379)")
+	fs.Var(&db, "db", "Redis DB (default: afs.config.json redisDB, else 0)")
+	fs.Var(&key, "key", "agent-filesystem key name (default: afs.config.json redisKey)")
+	fs.Var(&index, "index", "RediSearch index name (default: afs_idx:{<key>})")
+	if err := fs.Parse(args); err != nil {
+		return opts, nil, err
+	}
+
+	opts.redisConfig = controlplane.Config{
+		RedisAddr: "127.0.0.1:6379",
+		RedisDB:   0,
+	}
+
+	cfg, present, err := controlplane.LoadConfigWithPresence(configPath)
+	if err != nil {
+		return opts, nil, err
+	}
+	if present {
+		opts.redisConfig = cfg
+		opts.key = cfg.RedisKey
+	}
+
+	if addr.set {
+		opts.redisConfig.RedisAddr = addr.value
+	}
+	if db.set {
+		opts.redisConfig.RedisDB = db.value
+	}
+	if key.set {
+		opts.key = key.value
+	}
+	if index.set {
+		opts.index = index.value
+	}
+
+	if strings.TrimSpace(opts.key) == "" {
+		return opts, nil, fmt.Errorf("--key is required when afs.config.json does not provide redisKey")
+	}
+	if opts.redisConfig.RedisDB < 0 {
+		return opts, nil, fmt.Errorf("redis db must be >= 0")
+	}
+
+	return opts, fs.Args(), nil
+}
+
+func printUsage(w io.Writer) {
+	fmt.Fprintln(w, "usage: redis-qmd [flags] <command> [args...]")
+	fmt.Fprintln(w, "commands: doctor, index <create|rebuild|info>, search <text>, query <dsl>")
+	flagDefaults := []struct {
+		name string
+		help string
+	}{
+		{"-config", "path to afs.config.json"},
+		{"-addr", "Redis host:port (default: afs.config.json redisAddr, else 127.0.0.1:6379)"},
+		{"-db", "Redis DB (default: afs.config.json redisDB, else 0)"},
+		{"-key", "agent-filesystem key name (default: afs.config.json redisKey)"},
+		{"-index", "RediSearch index name (default: afs_idx:{<key>})"},
+	}
+	fmt.Fprintln(w, "flags:")
+	for _, row := range flagDefaults {
+		fmt.Fprintf(w, "  %-8s %s\n", row.name, row.help)
 	}
 }

--- a/cli/cmd/redis-qmd/main_test.go
+++ b/cli/cmd/redis-qmd/main_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseCLIUsesConfigDefaults(t *testing.T) {
+	configFile := writeQMDConfig(t, `{
+  "redisAddr": "redis.example:6380",
+  "redisDB": 7,
+  "redisKey": "demo"
+}`)
+
+	opts, args, err := parseCLI([]string{"--config", configFile, "doctor"})
+	if err != nil {
+		t.Fatalf("parseCLI() returned error: %v", err)
+	}
+	if len(args) != 1 || args[0] != "doctor" {
+		t.Fatalf("args = %v, want [doctor]", args)
+	}
+	if opts.redisConfig.RedisAddr != "redis.example:6380" {
+		t.Fatalf("RedisAddr = %q, want %q", opts.redisConfig.RedisAddr, "redis.example:6380")
+	}
+	if opts.redisConfig.RedisDB != 7 {
+		t.Fatalf("RedisDB = %d, want %d", opts.redisConfig.RedisDB, 7)
+	}
+	if opts.key != "demo" {
+		t.Fatalf("key = %q, want %q", opts.key, "demo")
+	}
+}
+
+func TestParseCLIFlagsOverrideConfigDefaults(t *testing.T) {
+	configFile := writeQMDConfig(t, `{
+  "redisAddr": "redis.example:6380",
+  "redisDB": 7,
+  "redisKey": "demo"
+}`)
+
+	opts, args, err := parseCLI([]string{
+		"--config", configFile,
+		"--addr", "127.0.0.1:6390",
+		"--db", "3",
+		"--key", "override",
+		"--index", "custom-index",
+		"search", "TODO",
+	})
+	if err != nil {
+		t.Fatalf("parseCLI() returned error: %v", err)
+	}
+	if len(args) != 2 || args[0] != "search" || args[1] != "TODO" {
+		t.Fatalf("args = %v, want [search TODO]", args)
+	}
+	if opts.redisConfig.RedisAddr != "127.0.0.1:6390" {
+		t.Fatalf("RedisAddr = %q, want %q", opts.redisConfig.RedisAddr, "127.0.0.1:6390")
+	}
+	if opts.redisConfig.RedisDB != 3 {
+		t.Fatalf("RedisDB = %d, want %d", opts.redisConfig.RedisDB, 3)
+	}
+	if opts.key != "override" {
+		t.Fatalf("key = %q, want %q", opts.key, "override")
+	}
+	if opts.index != "custom-index" {
+		t.Fatalf("index = %q, want %q", opts.index, "custom-index")
+	}
+}
+
+func TestParseCLIUsesStandaloneDefaultsWhenConfigMissing(t *testing.T) {
+	opts, args, err := parseCLI([]string{"--key", "demo", "doctor"})
+	if err != nil {
+		t.Fatalf("parseCLI() returned error: %v", err)
+	}
+	if len(args) != 1 || args[0] != "doctor" {
+		t.Fatalf("args = %v, want [doctor]", args)
+	}
+	if opts.redisConfig.RedisAddr != "127.0.0.1:6379" {
+		t.Fatalf("RedisAddr = %q, want %q", opts.redisConfig.RedisAddr, "127.0.0.1:6379")
+	}
+	if opts.redisConfig.RedisDB != 0 {
+		t.Fatalf("RedisDB = %d, want %d", opts.redisConfig.RedisDB, 0)
+	}
+}
+
+func TestParseCLIRequiresKeyWithoutConfigDefault(t *testing.T) {
+	_, _, err := parseCLI([]string{"doctor"})
+	if err == nil {
+		t.Fatal("parseCLI() returned nil error, want missing key error")
+	}
+	if !strings.Contains(err.Error(), "--key is required") {
+		t.Fatalf("parseCLI() error = %q, want missing key message", err)
+	}
+}
+
+func writeQMDConfig(t *testing.T, contents string) string {
+	t.Helper()
+
+	configFile := filepath.Join(t.TempDir(), "afs.config.json")
+	if err := os.WriteFile(configFile, []byte(contents), 0o644); err != nil {
+		t.Fatalf("os.WriteFile() returned error: %v", err)
+	}
+	return configFile
+}

--- a/cli/config_commands.go
+++ b/cli/config_commands.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -9,8 +11,12 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
 )
 
 type optionalString struct {
@@ -168,21 +174,245 @@ func cmdConfigSet(args []string) error {
 }
 
 func loadConfigForUp(args []string) (config, error) {
-	cfg, _, err := loadConfigWithPresence()
+	return loadConfigForUpWithIO(args, bufio.NewReader(os.Stdin), os.Stdout, isInteractiveTerminal())
+}
+
+type upConfigPresence struct {
+	filePresent       bool
+	redisDBPresent    bool
+	mountpointPresent bool
+}
+
+func loadConfigForUpWithIO(args []string, r *bufio.Reader, out io.Writer, allowPrompt bool) (config, error) {
+	cfg, presence, err := loadConfigWithUpPresence()
 	if err != nil {
 		return cfg, err
 	}
-	overrides, _, err := parseConfigOverrideFlags("up", args, false)
-	if err != nil {
+
+	changed := false
+	switch len(args) {
+	case 0:
+		changed, err = promptForMissingUpConfig(&cfg, presence, r, out, allowPrompt)
+		if err != nil {
+			return cfg, err
+		}
+	case 2:
+		if err := applyUpWorkspaceAndMountpoint(&cfg, args[0], args[1]); err != nil {
+			return cfg, err
+		}
+		changed = true
+	default:
+		return cfg, fmt.Errorf("%s", upUsageText(filepath.Base(os.Args[0])))
+	}
+
+	if changed {
+		if err := persistConfigForUp(&cfg); err != nil {
+			return cfg, err
+		}
+	}
+	if err := resolveConfigPaths(&cfg); err != nil {
 		return cfg, err
 	}
-	if err := applyConfigOverrides(&cfg, overrides); err != nil {
+	return cfg, nil
+}
+
+func prepareMountedConfig(cfg config, workspace, mountpoint string) (config, error) {
+	if err := applyUpWorkspaceAndMountpoint(&cfg, workspace, mountpoint); err != nil {
 		return cfg, err
 	}
 	if err := resolveConfigPaths(&cfg); err != nil {
 		return cfg, err
 	}
 	return cfg, nil
+}
+
+func applyUpWorkspaceAndMountpoint(cfg *config, workspace, mountpoint string) error {
+	if cfg == nil {
+		return fmt.Errorf("missing config")
+	}
+	if err := validateAFSName("workspace", workspace); err != nil {
+		return err
+	}
+
+	backendName, err := normalizeMountBackend(cfg.MountBackend)
+	if err != nil {
+		return err
+	}
+	if backendName == mountBackendNone {
+		return fmt.Errorf("filesystem mounts are disabled in config\nRun '%s config set --mount-backend nfs --mountpoint %s' or similar first", filepath.Base(os.Args[0]), mountpoint)
+	}
+
+	cfg.CurrentWorkspace = workspace
+	cfg.Mountpoint = mountpoint
+	return nil
+}
+
+func loadConfigWithUpPresence() (config, upConfigPresence, error) {
+	cfg := defaultConfig()
+	var presence upConfigPresence
+
+	raw, err := os.ReadFile(configPath())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return cfg, presence, nil
+		}
+		return cfg, presence, err
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return cfg, presence, err
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return cfg, presence, err
+	}
+
+	presence.filePresent = true
+	_, presence.redisDBPresent = fields["redisDB"]
+	_, presence.mountpointPresent = fields["mountpoint"]
+	return cfg, presence, nil
+}
+
+func promptForMissingUpConfig(cfg *config, presence upConfigPresence, r *bufio.Reader, out io.Writer, allowPrompt bool) (bool, error) {
+	if cfg == nil {
+		return false, fmt.Errorf("missing config")
+	}
+
+	backendName, err := normalizeMountBackend(cfg.MountBackend)
+	if err != nil {
+		return false, err
+	}
+
+	missingDatabase := !presence.filePresent || !presence.redisDBPresent
+	missingWorkspace := backendName != mountBackendNone && strings.TrimSpace(cfg.CurrentWorkspace) == ""
+	missingMountpoint := backendName != mountBackendNone && (!presence.filePresent || !presence.mountpointPresent || strings.TrimSpace(cfg.Mountpoint) == "")
+	if !missingDatabase && !missingWorkspace && !missingMountpoint {
+		return false, nil
+	}
+	if !allowPrompt {
+		return false, fmt.Errorf("config is missing settings required for 'up'\nRun '%s setup' or use an interactive terminal so AFS can prompt for the missing database, workspace, and mountpoint", filepath.Base(os.Args[0]))
+	}
+
+	changed := false
+	if missingDatabase {
+		value, err := promptString(r, out,
+			"  Redis database\n  "+clr(ansiDim, "Choose the Redis database number for this AFS config"),
+			strconv.Itoa(cfg.RedisDB))
+		if err != nil {
+			return false, err
+		}
+		db, err := strconv.Atoi(strings.TrimSpace(value))
+		if err != nil {
+			return false, fmt.Errorf("invalid redis database %q", value)
+		}
+		if db < 0 {
+			return false, fmt.Errorf("redis db must be >= 0")
+		}
+		cfg.RedisDB = db
+		changed = true
+	}
+
+	if missingWorkspace {
+		defaultWorkspace, hint := suggestUpWorkspace(*cfg)
+		label := "  Workspace"
+		if hint != "" {
+			label += "\n  " + clr(ansiDim, hint)
+		}
+		workspace, err := promptString(r, out, label, defaultWorkspace)
+		if err != nil {
+			return false, err
+		}
+		workspace = strings.TrimSpace(workspace)
+		if workspace == "" {
+			return false, fmt.Errorf("workspace name cannot be empty when starting a mounted filesystem")
+		}
+		if err := validateAFSName("workspace", workspace); err != nil {
+			return false, err
+		}
+		cfg.CurrentWorkspace = workspace
+		changed = true
+	}
+
+	if missingMountpoint {
+		defaultMountpoint := strings.TrimSpace(cfg.Mountpoint)
+		if defaultMountpoint == "" {
+			defaultMountpoint = defaultConfig().Mountpoint
+		}
+		mountpoint, err := promptString(r, out,
+			"  Local mountpoint\n  "+clr(ansiDim, "Directory where the workspace should be mounted"),
+			defaultMountpoint)
+		if err != nil {
+			return false, err
+		}
+		mountpoint = strings.TrimSpace(mountpoint)
+		if mountpoint == "" {
+			return false, fmt.Errorf("mountpoint cannot be empty when starting a mounted filesystem")
+		}
+		cfg.Mountpoint = mountpoint
+		changed = true
+	}
+
+	return changed, nil
+}
+
+func suggestUpWorkspace(cfg config) (string, string) {
+	names, err := existingWorkspaceNames(cfg)
+	if err != nil || len(names) == 0 {
+		return "", "Enter a workspace name to mount"
+	}
+	if len(names) == 1 {
+		return names[0], "Available workspace: " + names[0]
+	}
+	return names[0], "Available workspaces: " + strings.Join(names, ", ")
+}
+
+func existingWorkspaceNames(cfg config) ([]string, error) {
+	if !cfg.UseExistingRedis {
+		return nil, nil
+	}
+
+	redisCfg := cfg
+	if err := prepareConfigForSave(&redisCfg); err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	rdb := redis.NewClient(buildRedisOptions(redisCfg, 4))
+	defer rdb.Close()
+
+	if err := rdb.Ping(ctx).Err(); err != nil {
+		return nil, nil
+	}
+	workspaces, err := newAFSStore(rdb).listWorkspaces(ctx)
+	if err != nil {
+		return nil, nil
+	}
+
+	names := make([]string, 0, len(workspaces))
+	for _, workspace := range workspaces {
+		if strings.TrimSpace(workspace.Name) != "" {
+			names = append(names, workspace.Name)
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func persistConfigForUp(cfg *config) error {
+	if cfg == nil {
+		return fmt.Errorf("missing config")
+	}
+	persisted := *cfg
+	if err := prepareConfigForSave(&persisted); err != nil {
+		return err
+	}
+	if err := saveConfig(persisted); err != nil {
+		return err
+	}
+	*cfg = persisted
+	return nil
 }
 
 func loadConfigWithPresence() (config, bool, error) {
@@ -315,26 +545,22 @@ Examples:
 
 func upUsageText(bin string) string {
 	return fmt.Sprintf(`Usage:
-  %s up [flags...]
+  %s up
+  %s up <workspace> <mountpoint>
 
-Start AFS using the saved config, with optional one-shot overrides.
-These flags apply to the current run only and do not rewrite %s.
-
-Basics:
-  --redis-url <redis://...|rediss://...>
-  --mount-backend auto|none|fuse|nfs
-  --mountpoint <path>
-  --readonly[=true|false]
+Start AFS using the saved config.
+If <workspace> and <mountpoint> are provided, AFS saves them into %s before
+starting so future runs use the updated workspace and mountpoint.
 
 Notes:
-  Current workspace is not set here. Use '%s workspace use <workspace>'.
-  Advanced fields like runtime paths stay available in afs.config.json if needed.
+  Redis connection, mount backend, and readonly mode come from config.
+  If required settings are missing, AFS prompts for them in the terminal.
+  Use '%s config set ...' to change Redis or mount settings persistently.
 
 Examples:
-  %s up --redis-url rediss://user:pass@redis.example:6379/4
-  %s up --mount-backend none
-  %s up --mount-backend nfs --mountpoint ~/demo
-`, bin, compactDisplayPath(configPath()), bin, bin, bin, bin)
+  %s up
+  %s up claude-code ~/.claude
+`, bin, bin, compactDisplayPath(configPath()), bin, bin, bin)
 }
 
 func applyConfigOverrides(cfg *config, overrides configOverrides) error {

--- a/cli/config_commands_test.go
+++ b/cli/config_commands_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"os"
@@ -9,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
 )
 
 func TestCmdConfigSetPersistsNonInteractiveSettings(t *testing.T) {
@@ -107,7 +110,7 @@ func TestCmdConfigShowJSONIncludesConfiguredFields(t *testing.T) {
 	}
 }
 
-func TestLoadConfigForUpAppliesOverridesWithoutSaving(t *testing.T) {
+func TestLoadConfigForUpAppliesWorkspaceAndMountpointAndSavesConfig(t *testing.T) {
 	t.Helper()
 
 	homeDir := t.TempDir()
@@ -124,23 +127,16 @@ func TestLoadConfigForUpAppliesOverridesWithoutSaving(t *testing.T) {
 	base.RedisAddr = "127.0.0.1:6379"
 	base.RedisDB = 0
 	base.CurrentWorkspace = "alpha"
-	base.MountBackend = mountBackendNone
-	base.NFSBin = filepath.Join(t.TempDir(), "agent-filesystem-nfs")
+	base.MountBackend = mountBackendNFS
+	base.NFSBin = "/usr/bin/true"
 	saveTempConfig(t, base)
 
-	cfg, err := loadConfigForUp([]string{
-		"--redis-url", "rediss://127.0.0.1:6381/7",
-		"--mount-backend", "nfs",
-		"--mountpoint", "~/override",
-	})
+	cfg, err := loadConfigForUp([]string{"beta", "~/override"})
 	if err != nil {
 		t.Fatalf("loadConfigForUp() returned error: %v", err)
 	}
-	if cfg.RedisDB != 7 {
-		t.Fatalf("RedisDB = %d, want %d", cfg.RedisDB, 7)
-	}
-	if cfg.RedisAddr != "127.0.0.1:6381" {
-		t.Fatalf("RedisAddr = %q, want %q", cfg.RedisAddr, "127.0.0.1:6381")
+	if cfg.CurrentWorkspace != "beta" {
+		t.Fatalf("CurrentWorkspace = %q, want %q", cfg.CurrentWorkspace, "beta")
 	}
 	if cfg.MountBackend != mountBackendNFS {
 		t.Fatalf("MountBackend = %q, want %q", cfg.MountBackend, mountBackendNFS)
@@ -157,11 +153,96 @@ func TestLoadConfigForUpAppliesOverridesWithoutSaving(t *testing.T) {
 	if saved.RedisDB != 0 {
 		t.Fatalf("saved RedisDB = %d, want %d", saved.RedisDB, 0)
 	}
-	if saved.CurrentWorkspace != "alpha" {
-		t.Fatalf("saved CurrentWorkspace = %q, want %q", saved.CurrentWorkspace, "alpha")
+	if saved.CurrentWorkspace != "beta" {
+		t.Fatalf("saved CurrentWorkspace = %q, want %q", saved.CurrentWorkspace, "beta")
 	}
-	if saved.MountBackend != mountBackendNone {
-		t.Fatalf("saved MountBackend = %q, want %q", saved.MountBackend, mountBackendNone)
+	if saved.Mountpoint != wantMountpoint {
+		t.Fatalf("saved Mountpoint = %q, want %q", saved.Mountpoint, wantMountpoint)
+	}
+	if saved.MountBackend != mountBackendNFS {
+		t.Fatalf("saved MountBackend = %q, want %q", saved.MountBackend, mountBackendNFS)
+	}
+}
+
+func TestLoadConfigForUpPromptsForMissingDatabaseWorkspaceAndMountpoint(t *testing.T) {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", homeDir); err != nil {
+		t.Fatalf("Setenv(HOME) returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", origHome)
+	})
+
+	configFile := filepath.Join(t.TempDir(), "afs.config.json")
+	origConfigPath := cfgPathOverride
+	cfgPathOverride = configFile
+	t.Cleanup(func() {
+		cfgPathOverride = origConfigPath
+	})
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr(), DB: 7})
+	t.Cleanup(func() {
+		_ = rdb.Close()
+	})
+
+	cfg := defaultConfig()
+	cfg.UseExistingRedis = true
+	cfg.RedisAddr = mr.Addr()
+	cfg.RedisDB = 7
+	if err := createEmptyWorkspace(context.Background(), cfg, newAFSStore(rdb), "demo"); err != nil {
+		t.Fatalf("createEmptyWorkspace() returned error: %v", err)
+	}
+
+	raw := `{
+  "useExistingRedis": true,
+  "redisAddr": "` + mr.Addr() + `",
+  "mountBackend": "nfs",
+  "nfsBin": "/usr/bin/true"
+}`
+	if err := os.WriteFile(configFile, []byte(raw), 0o644); err != nil {
+		t.Fatalf("WriteFile(config) returned error: %v", err)
+	}
+
+	var output bytes.Buffer
+	got, err := loadConfigForUpWithIO(
+		[]string{},
+		bufio.NewReader(bytes.NewBufferString(stringsJoinLines("7", "", "/tmp/afs-demo"))),
+		&output,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("loadConfigForUpWithIO() returned error: %v", err)
+	}
+
+	if got.RedisDB != 7 {
+		t.Fatalf("RedisDB = %d, want %d", got.RedisDB, 7)
+	}
+	if got.CurrentWorkspace != "demo" {
+		t.Fatalf("CurrentWorkspace = %q, want %q", got.CurrentWorkspace, "demo")
+	}
+	if got.Mountpoint != "/tmp/afs-demo" {
+		t.Fatalf("Mountpoint = %q, want %q", got.Mountpoint, "/tmp/afs-demo")
+	}
+	if !strings.Contains(output.String(), "Available workspace: demo") {
+		t.Fatalf("prompt output = %q, want available workspace hint", output.String())
+	}
+
+	saved, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig(saved) returned error: %v", err)
+	}
+	if saved.RedisDB != 7 {
+		t.Fatalf("saved RedisDB = %d, want %d", saved.RedisDB, 7)
+	}
+	if saved.CurrentWorkspace != "demo" {
+		t.Fatalf("saved CurrentWorkspace = %q, want %q", saved.CurrentWorkspace, "demo")
+	}
+	if saved.Mountpoint != "/tmp/afs-demo" {
+		t.Fatalf("saved Mountpoint = %q, want %q", saved.Mountpoint, "/tmp/afs-demo")
 	}
 }
 
@@ -210,7 +291,35 @@ func TestCmdConfigSetHelpListsDetailedFlags(t *testing.T) {
 	}
 }
 
-func TestCmdUpHelpListsOneShotOverrides(t *testing.T) {
+func TestLoadConfigForUpRejectsSinglePositionalArgument(t *testing.T) {
+	t.Helper()
+
+	_, err := loadConfigForUp([]string{"claude-code"})
+	if err == nil {
+		t.Fatal("loadConfigForUp() returned nil error, want usage error")
+	}
+	if !strings.Contains(err.Error(), "up <workspace> <mountpoint>") {
+		t.Fatalf("loadConfigForUp() error = %q, want positional usage", err)
+	}
+}
+
+func TestLoadConfigForUpRejectsMountOverrideWhenMountsAreDisabledInConfig(t *testing.T) {
+	t.Helper()
+
+	base := defaultConfig()
+	base.MountBackend = mountBackendNone
+	saveTempConfig(t, base)
+
+	_, err := loadConfigForUp([]string{"claude-code", "~/claude"})
+	if err == nil {
+		t.Fatal("loadConfigForUp() returned nil error, want disabled mount backend error")
+	}
+	if !strings.Contains(err.Error(), "filesystem mounts are disabled in config") {
+		t.Fatalf("loadConfigForUp() error = %q, want disabled mount backend message", err)
+	}
+}
+
+func TestCmdUpHelpListsPositionalOverrides(t *testing.T) {
 	t.Helper()
 
 	out, err := captureStderr(t, func() error {
@@ -221,12 +330,11 @@ func TestCmdUpHelpListsOneShotOverrides(t *testing.T) {
 	}
 
 	for _, want := range []string{
-		"current run only",
-		"do not rewrite",
-		"--redis-url <redis://...|rediss://...>",
-		"--mount-backend auto|none|fuse|nfs",
-		"--mountpoint <path>",
-		"workspace use <workspace>",
+		"up <workspace> <mountpoint>",
+		"Redis connection, mount backend, and readonly mode come from config",
+		"AFS prompts for them in the terminal",
+		"config set",
+		"up claude-code ~/.claude",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("up help output = %q, want substring %q", out, want)
@@ -248,10 +356,10 @@ func TestCmdWorkspaceHelpListsSubcommands(t *testing.T) {
 		"workspace <subcommand>",
 		"current",
 		"use <workspace>",
-		"clone <workspace> <directory>",
-		"fork <source-workspace> <new-workspace>",
+		"clone [workspace] <directory>",
+		"fork [source-workspace] <new-workspace>",
 		"run [workspace] [--readonly] -- <command...>",
-		"import [--force] [--clone-at-source] <workspace> <directory>",
+		"import [--force] [--mount-at-source] <workspace> <directory>",
 		"workspace create demo",
 	} {
 		if !strings.Contains(out, want) {
@@ -336,8 +444,8 @@ func TestCmdCheckpointHelpListsSubcommands(t *testing.T) {
 
 	for _, want := range []string{
 		"checkpoint <subcommand>",
-		"create <workspace> [checkpoint]",
-		"restore <workspace> <checkpoint>",
+		"create [workspace] [checkpoint]",
+		"restore [workspace] <checkpoint>",
 		"checkpoint restore demo initial",
 	} {
 		if !strings.Contains(out, want) {
@@ -358,7 +466,7 @@ func TestCmdCheckpointRestoreHelpExplainsArchiveBehavior(t *testing.T) {
 
 	for _, want := range []string{
 		"Restore the workspace working copy to the selected checkpoint",
-		"checkpoint restore <workspace> <checkpoint>",
+		"checkpoint restore [workspace] <checkpoint>",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("checkpoint restore help output = %q, want substring %q", out, want)

--- a/cli/internal/controlplane/config.go
+++ b/cli/internal/controlplane/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -20,21 +21,36 @@ type Config struct {
 	RedisPassword string `json:"redisPassword"`
 	RedisDB       int    `json:"redisDB"`
 	RedisTLS      bool   `json:"redisTLS"`
+	RedisKey      string `json:"redisKey"`
 }
 
 func LoadConfig(configPathOverride string) (Config, error) {
+	cfg, present, err := LoadConfigWithPresence(configPathOverride)
+	if err != nil {
+		return cfg, err
+	}
+	if !present {
+		return cfg, fmt.Errorf("no configuration found\nCreate %s or run afs setup first", configPath(configPathOverride))
+	}
+	return cfg, nil
+}
+
+func LoadConfigWithPresence(configPathOverride string) (Config, bool, error) {
 	cfg := defaultConfig()
 	data, err := os.ReadFile(configPath(configPathOverride))
 	if err != nil {
-		return cfg, fmt.Errorf("no configuration found\nCreate %s or run afs setup first", configPath(configPathOverride))
+		if errors.Is(err, os.ErrNotExist) {
+			return cfg, false, nil
+		}
+		return cfg, false, err
 	}
 	if err := json.Unmarshal(data, &cfg); err != nil {
-		return cfg, err
+		return cfg, true, err
 	}
 	if err := prepareConfig(&cfg); err != nil {
-		return cfg, err
+		return cfg, true, err
 	}
-	return cfg, nil
+	return cfg, true, nil
 }
 
 func OpenStore(ctx context.Context, cfg Config) (*Store, func(), error) {
@@ -61,6 +77,10 @@ func buildRedisOptions(cfg Config, poolSize int) *redis.Options {
 	}
 }
 
+func NewRedisClient(cfg Config, poolSize int) *redis.Client {
+	return redis.NewClient(buildRedisOptions(cfg, poolSize))
+}
+
 func buildRedisTLSConfig(enabled bool) *tls.Config {
 	if !enabled {
 		return nil
@@ -83,6 +103,7 @@ func defaultConfig() Config {
 	return Config{
 		RedisAddr: "localhost:6379",
 		RedisDB:   0,
+		RedisKey:  "myfs",
 	}
 }
 

--- a/cli/internal/controlplane/http.go
+++ b/cli/internal/controlplane/http.go
@@ -146,6 +146,18 @@ func NewHandler(service *Service, allowOrigin string) http.Handler {
 					return
 				}
 				writeJSON(w, http.StatusOK, response)
+			case http.MethodPut:
+				var input UpdateWorkspaceRequest
+				if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+					writeError(w, fmt.Errorf("invalid request body: %w", err))
+					return
+				}
+				response, err := service.UpdateWorkspace(r.Context(), workspace, input)
+				if err != nil {
+					writeError(w, err)
+					return
+				}
+				writeJSON(w, http.StatusOK, response)
 			case http.MethodDelete:
 				if err := service.DeleteWorkspace(r.Context(), workspace); err != nil {
 					writeError(w, err)
@@ -168,7 +180,7 @@ func cors(next http.Handler, allowOrigin string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-		w.Header().Set("Access-Control-Allow-Methods", "GET,POST,DELETE,OPTIONS")
+		w.Header().Set("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS")
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return

--- a/cli/internal/controlplane/service.go
+++ b/cli/internal/controlplane/service.go
@@ -41,6 +41,7 @@ type capabilities struct {
 type workspaceSummary struct {
 	ID               string `json:"id"`
 	Name             string `json:"name"`
+	CloudAccount     string `json:"cloud_account"`
 	DatabaseID       string `json:"database_id"`
 	DatabaseName     string `json:"database_name"`
 	RedisKey         string `json:"redis_key"`
@@ -159,6 +160,13 @@ type createWorkspaceRequest struct {
 	Source       sourceRef `json:"source"`
 }
 
+type updateWorkspaceRequest struct {
+	Description  string `json:"description"`
+	DatabaseName string `json:"database_name"`
+	CloudAccount string `json:"cloud_account"`
+	Region       string `json:"region"`
+}
+
 type restoreCheckpointRequest struct {
 	CheckpointID string `json:"checkpoint_id"`
 }
@@ -185,6 +193,7 @@ type TreeResponse = treeResponse
 type FileContentResponse = fileContentResponse
 type SourceRef = sourceRef
 type CreateWorkspaceRequest = createWorkspaceRequest
+type UpdateWorkspaceRequest = updateWorkspaceRequest
 
 type SaveCheckpointRequest struct {
 	Workspace    string
@@ -211,6 +220,10 @@ func (s *Service) GetWorkspace(ctx context.Context, workspace string) (Workspace
 
 func (s *Service) CreateWorkspace(ctx context.Context, input CreateWorkspaceRequest) (WorkspaceDetail, error) {
 	return s.createWorkspace(ctx, input)
+}
+
+func (s *Service) UpdateWorkspace(ctx context.Context, workspace string, input UpdateWorkspaceRequest) (WorkspaceDetail, error) {
+	return s.updateWorkspace(ctx, workspace, input)
 }
 
 func (s *Service) DeleteWorkspace(ctx context.Context, workspace string) error {
@@ -312,7 +325,7 @@ func (s *Service) getWorkspace(ctx context.Context, workspace string) (workspace
 		CloudAccount:     meta.CloudAccount,
 		DatabaseID:       meta.DatabaseID,
 		DatabaseName:     meta.DatabaseName,
-		RedisKey:         fmt.Sprintf("afs:%s", meta.Name),
+		RedisKey:         WorkspaceFSKey(meta.Name),
 		Region:           meta.Region,
 		Status:           workspaceStatus(meta),
 		Source:           workspaceSource(meta),
@@ -387,6 +400,44 @@ func (s *Service) deleteWorkspace(ctx context.Context, workspace string) error {
 	return s.store.DeleteWorkspace(ctx, workspace)
 }
 
+func (s *Service) updateWorkspace(ctx context.Context, workspace string, input updateWorkspaceRequest) (workspaceDetail, error) {
+	if err := ValidateName("workspace", workspace); err != nil {
+		return workspaceDetail{}, err
+	}
+	meta, err := s.store.GetWorkspaceMeta(ctx, workspace)
+	if err != nil {
+		return workspaceDetail{}, err
+	}
+	databaseName := strings.TrimSpace(input.DatabaseName)
+	if databaseName == "" {
+		return workspaceDetail{}, fmt.Errorf("database name is required")
+	}
+	cloudAccount := strings.TrimSpace(input.CloudAccount)
+	if cloudAccount == "" {
+		return workspaceDetail{}, fmt.Errorf("cloud account is required")
+	}
+
+	meta = applyWorkspaceMetaDefaults(s.cfg, meta)
+	meta.Description = strings.TrimSpace(input.Description)
+	meta.DatabaseName = databaseName
+	meta.CloudAccount = cloudAccount
+	meta.Region = strings.TrimSpace(input.Region)
+	meta.Tags = workspaceTags(meta.Region, workspaceSource(meta))
+	meta.UpdatedAt = time.Now().UTC()
+
+	if err := s.store.PutWorkspaceMeta(ctx, meta); err != nil {
+		return workspaceDetail{}, err
+	}
+	if err := s.store.Audit(ctx, workspace, "workspace_update", map[string]any{
+		"database_name": meta.DatabaseName,
+		"cloud_account": meta.CloudAccount,
+		"region":        meta.Region,
+	}); err != nil {
+		return workspaceDetail{}, err
+	}
+	return s.getWorkspace(ctx, workspace)
+}
+
 func (s *Service) listCheckpoints(ctx context.Context, workspace string, limit int) ([]checkpointSummary, error) {
 	if limit <= 0 {
 		limit = 100
@@ -434,6 +485,13 @@ func (s *Service) restoreCheckpoint(ctx context.Context, workspace, checkpointID
 		if err == redis.TxFailedErr {
 			return ErrWorkspaceConflict
 		}
+		return err
+	}
+	manifestValue, err := s.store.GetManifest(ctx, workspace, checkpointID)
+	if err != nil {
+		return err
+	}
+	if err := SyncWorkspaceRoot(ctx, s.store, workspace, manifestValue); err != nil {
 		return err
 	}
 	return s.store.Audit(ctx, workspace, "checkpoint_restore", map[string]any{
@@ -554,6 +612,9 @@ func (s *Service) saveCheckpoint(ctx context.Context, input SaveCheckpointReques
 		}
 		return false, err
 	}
+	if err := SyncWorkspaceRoot(ctx, s.store, input.Workspace, input.Manifest); err != nil {
+		return false, err
+	}
 
 	if err := s.store.Audit(ctx, input.Workspace, "save", map[string]any{
 		"savepoint": input.CheckpointID,
@@ -650,6 +711,9 @@ func (s *Service) forkWorkspace(ctx context.Context, sourceWorkspace, newWorkspa
 		return err
 	}
 	if err := s.store.PutSavepoint(ctx, checkpointMeta, newManifest); err != nil {
+		return err
+	}
+	if err := SyncWorkspaceRoot(ctx, s.store, newWorkspace, newManifest); err != nil {
 		return err
 	}
 	return s.store.Audit(ctx, newWorkspace, "workspace_fork", map[string]any{
@@ -843,9 +907,10 @@ func (s *Service) buildWorkspaceSummary(ctx context.Context, meta WorkspaceMeta)
 	return workspaceSummary{
 		ID:               meta.Name,
 		Name:             meta.Name,
+		CloudAccount:     meta.CloudAccount,
 		DatabaseID:       meta.DatabaseID,
 		DatabaseName:     meta.DatabaseName,
-		RedisKey:         fmt.Sprintf("afs:%s", meta.Name),
+		RedisKey:         WorkspaceFSKey(meta.Name),
 		Status:           workspaceStatus(meta),
 		FileCount:        headMeta.FileCount,
 		FolderCount:      headMeta.DirCount,
@@ -958,6 +1023,9 @@ func createWorkspaceWithMetadata(ctx context.Context, cfg Config, store *Store, 
 		return err
 	}
 	if err := store.PutSavepoint(ctx, checkpointMeta, rootManifest); err != nil {
+		return err
+	}
+	if err := SyncWorkspaceRoot(ctx, store, workspace, rootManifest); err != nil {
 		return err
 	}
 	return store.Audit(ctx, workspace, "workspace_create", map[string]any{

--- a/cli/internal/controlplane/workspace_root.go
+++ b/cli/internal/controlplane/workspace_root.go
@@ -1,0 +1,201 @@
+package controlplane
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rowantrollope/agent-filesystem/mount/client"
+)
+
+func WorkspaceFSKey(workspace string) string {
+	return workspace
+}
+
+func EnsureWorkspaceRoot(ctx context.Context, store *Store, workspace string) (string, string, bool, error) {
+	meta, err := store.GetWorkspaceMeta(ctx, workspace)
+	if err != nil {
+		return "", "", false, err
+	}
+
+	exists, err := workspaceRootExists(ctx, store.rdb, workspace)
+	if err != nil {
+		return "", "", false, err
+	}
+	if exists {
+		return WorkspaceFSKey(workspace), meta.HeadSavepoint, false, nil
+	}
+
+	headManifest, err := store.GetManifest(ctx, workspace, meta.HeadSavepoint)
+	if err != nil {
+		return "", "", false, err
+	}
+	if err := SyncWorkspaceRoot(ctx, store, workspace, headManifest); err != nil {
+		return "", "", false, err
+	}
+	return WorkspaceFSKey(workspace), meta.HeadSavepoint, true, nil
+}
+
+func SyncWorkspaceRoot(ctx context.Context, store *Store, workspace string, m Manifest) error {
+	fsKey := WorkspaceFSKey(workspace)
+	if err := resetWorkspaceFSNamespace(ctx, store.rdb, fsKey); err != nil {
+		return err
+	}
+	fsClient := client.New(store.rdb, fsKey)
+	return materializeManifestToWorkspaceFS(ctx, store, workspace, fsClient, m)
+}
+
+func workspaceRootExists(ctx context.Context, rdb *redis.Client, workspace string) (bool, error) {
+	fsKey := WorkspaceFSKey(workspace)
+	count, err := rdb.Exists(ctx,
+		"afs:{"+fsKey+"}:info",
+		"afs:{"+fsKey+"}:inode:1",
+	).Result()
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func resetWorkspaceFSNamespace(ctx context.Context, rdb *redis.Client, fsKey string) error {
+	patterns := []string{
+		"afs:{" + fsKey + "}:inode:*",
+		"afs:{" + fsKey + "}:dirents:*",
+		"afs:{" + fsKey + "}:locks:*",
+	}
+	for _, pattern := range patterns {
+		var cursor uint64
+		for {
+			keys, next, err := rdb.Scan(ctx, cursor, pattern, 500).Result()
+			if err != nil {
+				return err
+			}
+			if len(keys) > 0 {
+				if err := rdb.Del(ctx, keys...).Err(); err != nil {
+					return err
+				}
+			}
+			cursor = next
+			if cursor == 0 {
+				break
+			}
+		}
+	}
+	if err := rdb.Del(ctx,
+		"afs:{"+fsKey+"}:info",
+		"afs:{"+fsKey+"}:next_inode",
+	).Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func materializeManifestToWorkspaceFS(ctx context.Context, store *Store, workspace string, fsClient client.Client, m Manifest) error {
+	rootEntry := ManifestEntry{Type: "dir", Mode: 0o755}
+	if entry, ok := m.Entries["/"]; ok {
+		rootEntry = entry
+	}
+
+	if err := fsClient.Mkdir(ctx, "/"); err != nil {
+		return err
+	}
+
+	dirs, others := manifestPathsForWorkspaceFS(m)
+	for _, manifestPath := range dirs {
+		if err := fsClient.Mkdir(ctx, manifestPath); err != nil {
+			return fmt.Errorf("mkdir %s: %w", manifestPath, err)
+		}
+	}
+
+	for _, manifestPath := range others {
+		entry := m.Entries[manifestPath]
+		switch entry.Type {
+		case "file":
+			data, err := ManifestEntryData(entry, func(blobID string) ([]byte, error) {
+				return store.GetBlob(ctx, workspace, blobID)
+			})
+			if err != nil {
+				return err
+			}
+			if err := fsClient.EchoCreate(ctx, manifestPath, data, manifestEntryModeForWorkspaceFS(entry)); err != nil {
+				return fmt.Errorf("write %s: %w", manifestPath, err)
+			}
+		case "symlink":
+			if err := fsClient.Ln(ctx, entry.Target, manifestPath); err != nil {
+				return fmt.Errorf("symlink %s: %w", manifestPath, err)
+			}
+		default:
+			return fmt.Errorf("unsupported manifest entry type %q", entry.Type)
+		}
+		if err := applyManifestEntryMetadataToWorkspaceFS(ctx, fsClient, manifestPath, entry); err != nil {
+			return err
+		}
+	}
+
+	for i := len(dirs) - 1; i >= 0; i-- {
+		manifestPath := dirs[i]
+		if err := applyManifestEntryMetadataToWorkspaceFS(ctx, fsClient, manifestPath, m.Entries[manifestPath]); err != nil {
+			return err
+		}
+	}
+
+	return applyManifestEntryMetadataToWorkspaceFS(ctx, fsClient, "/", rootEntry)
+}
+
+func applyManifestEntryMetadataToWorkspaceFS(ctx context.Context, fsClient client.Client, path string, entry ManifestEntry) error {
+	if err := fsClient.Chmod(ctx, path, manifestEntryModeForWorkspaceFS(entry)); err != nil {
+		return fmt.Errorf("chmod %s: %w", path, err)
+	}
+	if err := fsClient.Utimens(ctx, path, entry.MtimeMs, entry.MtimeMs); err != nil {
+		return fmt.Errorf("utimens %s: %w", path, err)
+	}
+	return nil
+}
+
+func manifestPathsForWorkspaceFS(m Manifest) ([]string, []string) {
+	paths := make([]string, 0, len(m.Entries))
+	for manifestPath := range m.Entries {
+		paths = append(paths, manifestPath)
+	}
+	sort.Strings(paths)
+
+	dirs := make([]string, 0, len(paths))
+	others := make([]string, 0, len(paths))
+	for _, manifestPath := range paths {
+		if manifestPath == "/" {
+			continue
+		}
+		if m.Entries[manifestPath].Type == "dir" {
+			dirs = append(dirs, manifestPath)
+		} else {
+			others = append(others, manifestPath)
+		}
+	}
+
+	sort.Slice(dirs, func(i, j int) bool {
+		if len(dirs[i]) == len(dirs[j]) {
+			return dirs[i] < dirs[j]
+		}
+		return len(dirs[i]) < len(dirs[j])
+	})
+	return dirs, others
+}
+
+func manifestEntryModeForWorkspaceFS(entry ManifestEntry) uint32 {
+	switch entry.Type {
+	case "dir":
+		if entry.Mode == 0 {
+			return 0o755
+		}
+	case "symlink":
+		if entry.Mode == 0 {
+			return 0o777
+		}
+	default:
+		if entry.Mode == 0 {
+			return 0o644
+		}
+	}
+	return entry.Mode
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -66,6 +66,7 @@ type state struct {
 	ReadOnly             bool      `json:"read_only"`
 	MountEndpoint        string    `json:"mount_endpoint,omitempty"`
 	Mountpoint           string    `json:"mountpoint"`
+	CreatedMountpoint    bool      `json:"created_mountpoint,omitempty"`
 	RedisKey             string    `json:"redis_key"`
 	RedisLog             string    `json:"redis_log"`
 	MountLog             string    `json:"mount_log"`
@@ -168,7 +169,10 @@ func printUsage() {
 Commands:
   setup                Interactive setup
   config ...           Show or change basic Redis and mount settings non-interactively
-  up [flags]           Start AFS services with optional one-shot overrides
+  up                   Start AFS services using the saved config
+  up <workspace> <mountpoint>
+                       Start AFS services using config, overriding workspace
+                       and mountpoint for this run
   down                 Stop and unmount
   status               Show current status
   workspace ...        Workspace operations (create, list, current, use, run, clone, fork, delete, import)
@@ -199,7 +203,7 @@ func statusTitle(prefix, backendName, workspace, localPath string) string {
 	if backendName == mountBackendNone {
 		return prefix + " " + clr(ansiBold, "afs no mounted filesystem")
 	}
-	return prefix + " " + clr(ansiBold, fmt.Sprintf("Workspace: %s mounted at %s (via %s)", currentWorkspaceLabel(workspace), localPath, userModeLabel(backendName)))
+	return prefix + " " + clr(ansiBold, fmt.Sprintf("Workspace mounted via %s", userModeLabel(backendName)))
 }
 
 func localSurfacePath(cfg config, backendName string) string {
@@ -673,45 +677,6 @@ func cmdDown() error {
 	}
 
 	var rdb *redis.Client
-	if st.MountBackend != mountBackendNone && !st.ReadOnly && strings.TrimSpace(st.CurrentWorkspace) != "" && strings.TrimSpace(st.RedisKey) != "" {
-		redisCfg := cfg
-		redisCfg.RedisAddr = st.RedisAddr
-		redisCfg.RedisDB = st.RedisDB
-
-		rdb = redis.NewClient(buildRedisOptions(redisCfg, 8))
-		pingCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		err = rdb.Ping(pingCtx).Err()
-		cancel()
-		if err != nil {
-			fmt.Printf("  %s mounted workspace could not be saved; continuing shutdown (%v)\n", clr(ansiYellow, "!"), err)
-		} else {
-			expectedHead := strings.TrimSpace(st.MountedHeadSavepoint)
-			if expectedHead == "" {
-				store := newAFSStore(rdb)
-				workspaceMeta, metaErr := store.getWorkspaceMeta(context.Background(), st.CurrentWorkspace)
-				if metaErr != nil {
-					fmt.Printf("  %s mounted workspace could not be saved; continuing shutdown (%v)\n", clr(ansiYellow, "!"), metaErr)
-				} else {
-					expectedHead = workspaceMeta.HeadSavepoint
-				}
-			}
-
-			if expectedHead != "" {
-				s := startStep("Saving mounted workspace")
-				saved, syncErr := syncMountedWorkspaceBack(context.Background(), cfg, newAFSStore(rdb), rdb, st.CurrentWorkspace, expectedHead)
-				if syncErr != nil {
-					s.fail(syncErr.Error())
-					fmt.Printf("  %s mounted changes for %s were not saved; continuing shutdown\n", clr(ansiYellow, "!"), st.CurrentWorkspace)
-				} else if saved {
-					s.succeed(st.CurrentWorkspace)
-				} else {
-					s.succeed("no changes")
-				}
-			} else {
-				fmt.Printf("  %s mounted workspace head is unavailable; continuing shutdown without saving\n", clr(ansiYellow, "!"))
-			}
-		}
-	}
 
 	// Always attempt unmount — even if the daemon crashed, the stale mount
 	// may still be in the mount table and block access to the mountpoint.
@@ -732,7 +697,11 @@ func cmdDown() error {
 		s.succeed(fmt.Sprintf("pid %d", st.MountPID))
 	}
 
-	if rdb != nil && strings.TrimSpace(st.RedisKey) != "" && !backend.IsMounted(st.Mountpoint) {
+	if shouldCleanLegacyMountCache(st) && !backend.IsMounted(st.Mountpoint) {
+		redisCfg := cfg
+		redisCfg.RedisAddr = st.RedisAddr
+		redisCfg.RedisDB = st.RedisDB
+		rdb = redis.NewClient(buildRedisOptions(redisCfg, 4))
 		s := startStep("Cleaning mount cache")
 		if err := deleteNamespace(context.Background(), rdb, st.RedisKey); err != nil {
 			s.fail(err.Error())
@@ -768,6 +737,14 @@ func cmdDown() error {
 				fmt.Printf("  %s mount still active, archive preserved at %s\n",
 					clr(ansiYellow, "!"), st.ArchivePath)
 			}
+		}
+	}
+
+	if st.CreatedMountpoint && st.ArchivePath == "" && !backend.IsMounted(st.Mountpoint) {
+		removeErr := removeEmptyMountpoint(st.Mountpoint)
+		if removeErr != nil {
+			fmt.Printf("  %s empty mountpoint at %s could not be removed automatically (%v)\n",
+				clr(ansiYellow, "!"), st.Mountpoint, removeErr)
 		}
 	}
 
@@ -918,18 +895,29 @@ func startServices(cfg config) error {
 	} else {
 		workspaceStep.succeed(workspace)
 	}
-	prepareStep := startStep("Preparing mounted workspace")
-	mountKey, mountedHeadSavepoint, err := seedWorkspaceMountKey(ctx, cfg, store, rdb, workspace)
+	prepareStep := startStep("Opening live workspace")
+	mountKey, mountedHeadSavepoint, initialized, err := seedWorkspaceMountKey(ctx, store, workspace)
 	if err != nil {
 		prepareStep.fail(err.Error())
 		return err
 	}
-	prepareStep.succeed(workspace)
+	if initialized {
+		prepareStep.succeed(workspace + " (initialized)")
+	} else {
+		prepareStep.succeed(workspace)
+	}
 
 	mountCfg := cfg
 	mountCfg.RedisKey = mountKey
 
 	s = startStep("Mounting filesystem")
+	createdMountpoint := false
+	if _, statErr := os.Stat(mountCfg.Mountpoint); errors.Is(statErr, os.ErrNotExist) {
+		createdMountpoint = true
+	} else if statErr != nil {
+		s.fail(statErr.Error())
+		return fmt.Errorf("check mountpoint: %w", statErr)
+	}
 	if err := os.MkdirAll(mountCfg.Mountpoint, 0o755); err != nil {
 		s.fail(err.Error())
 		return fmt.Errorf("create mountpoint: %w", err)
@@ -958,6 +946,7 @@ func startServices(cfg config) error {
 		ReadOnly:             cfg.ReadOnly,
 		MountEndpoint:        started.Endpoint,
 		Mountpoint:           mountCfg.Mountpoint,
+		CreatedMountpoint:    createdMountpoint,
 		RedisKey:             mountCfg.RedisKey,
 		RedisLog:             cfg.RedisLog,
 		MountLog:             cfg.MountLog,
@@ -1385,44 +1374,8 @@ func importDirectory(ctx context.Context, fsClient importClient, source string, 
 }
 
 func scanDirectory(source string, ignorer *migrationIgnore) (importStats, error) {
-	var stats importStats
-	err := filepath.WalkDir(source, func(path string, d os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if path == source {
-			return nil
-		}
-
-		skip, err := ignorer.matches(source, path, d)
-		if err != nil {
-			return err
-		}
-		if skip {
-			stats.Ignored++
-			if d.IsDir() {
-				return filepath.SkipDir
-			}
-			return nil
-		}
-
-		info, err := os.Lstat(path)
-		if err != nil {
-			return err
-		}
-
-		switch {
-		case d.Type()&os.ModeSymlink != 0:
-			stats.Symlinks++
-		case d.IsDir():
-			stats.Dirs++
-		default:
-			stats.Files++
-			stats.Bytes += info.Size()
-		}
-		return nil
-	})
-	return stats, err
+	report, err := scanDirectoryReport(source, ignorer, 0)
+	return report.Stats, err
 }
 
 func formatBytes(size int64) string {
@@ -1519,6 +1472,29 @@ func deleteNamespace(ctx context.Context, rdb *redis.Client, fsKey string) error
 		}
 	}
 	return nil
+}
+
+func shouldCleanLegacyMountCache(st state) bool {
+	redisKey := strings.TrimSpace(st.RedisKey)
+	if redisKey == "" {
+		return false
+	}
+	workspace := strings.TrimSpace(st.CurrentWorkspace)
+	if workspace == "" {
+		return true
+	}
+	return redisKey != workspaceRedisKey(workspace)
+}
+
+func removeEmptyMountpoint(path string) error {
+	err := os.Remove(path)
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if errors.Is(err, syscall.ENOTEMPTY) || errors.Is(err, syscall.EEXIST) {
+		return nil
+	}
+	return err
 }
 
 func terminatePID(pid int, timeout time.Duration) error {

--- a/cli/migration_ignore.go
+++ b/cli/migration_ignore.go
@@ -17,9 +17,11 @@ const (
 )
 
 type migrationIgnore struct {
-	path    string
-	legacy  bool
-	matcher ignore.IgnoreParser
+	path      string
+	legacy    bool
+	matcher   ignore.IgnoreParser
+	tempFiles map[string]struct{}
+	tempDirs  map[string]struct{}
 }
 
 func loadMigrationIgnore(sourceDir string) (*migrationIgnore, error) {
@@ -58,7 +60,7 @@ func (m *migrationIgnore) matches(sourceDir, path string, d fs.DirEntry) (bool, 
 		return false, nil
 	}
 
-	rel, err := filepath.Rel(sourceDir, path)
+	rel, err := relativeImportPath(sourceDir, path)
 	if err != nil {
 		return false, err
 	}
@@ -66,9 +68,42 @@ func (m *migrationIgnore) matches(sourceDir, path string, d fs.DirEntry) (bool, 
 		return false, nil
 	}
 
-	candidate := filepath.ToSlash(rel)
+	if m.matchesTemporary(rel) {
+		return true, nil
+	}
+
+	candidate := rel
 	if d.IsDir() && !strings.HasSuffix(candidate, "/") {
 		candidate += "/"
 	}
+	if m.matcher == nil {
+		return false, nil
+	}
 	return m.matcher.MatchesPath(candidate), nil
+}
+
+func (m *migrationIgnore) matchesTemporary(rel string) bool {
+	if m == nil {
+		return false
+	}
+	if _, ok := m.tempFiles[rel]; ok {
+		return true
+	}
+	for dir := range m.tempDirs {
+		if rel == dir || strings.HasPrefix(rel, dir+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func relativeImportPath(sourceDir, path string) (string, error) {
+	rel, err := filepath.Rel(sourceDir, path)
+	if err != nil {
+		return "", err
+	}
+	if rel == "." {
+		return rel, nil
+	}
+	return filepath.ToSlash(rel), nil
 }

--- a/cli/qmd_autoindex.go
+++ b/cli/qmd_autoindex.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rowantrollope/agent-filesystem/cli/qmd"
+)
+
+func ensureWorkspaceSearchIndex(ctx context.Context, rdb *redis.Client, fsKey string) {
+	if rdb == nil || strings.TrimSpace(fsKey) == "" {
+		return
+	}
+
+	client := qmd.NewClient(rdb, fsKey, "")
+	if _, err := rdb.Do(ctx, "FT._LIST").Result(); err != nil {
+		return
+	}
+	_ = client.CreateIndex(ctx)
+}

--- a/cli/ui.go
+++ b/cli/ui.go
@@ -463,6 +463,19 @@ func formatDuration(d time.Duration) string {
 	return fmt.Sprintf("%dh %dm", int(d.Hours()), int(d.Minutes())%60)
 }
 
+func formatDisplayTimestamp(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return raw
+	}
+	return parsed.Local().Format("Jan 2, 2006 3:04 PM")
+}
+
 func pidStatusColored(pid int) string {
 	if pid <= 0 {
 		return "unknown"

--- a/cli/workspace_checkpoint_commands.go
+++ b/cli/workspace_checkpoint_commands.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 	"github.com/rowantrollope/agent-filesystem/cli/internal/controlplane"
@@ -176,7 +177,7 @@ func cmdWorkspaceCurrent(args []string) error {
 	}
 
 	printBox(clr(ansiBold, "current workspace"), []boxRow{
-		{Label: "workspace", Value: currentWorkspaceLabel(cfg.CurrentWorkspace)},
+		{Label: "workspace", Value: currentWorkspaceLabel(selectedWorkspaceName(cfg))},
 	})
 	return nil
 }
@@ -319,17 +320,29 @@ func cmdWorkspaceClone(args []string) error {
 		fmt.Fprint(os.Stderr, workspaceCloneUsageText(filepath.Base(os.Args[0])))
 		return nil
 	}
-	if len(args) != 4 {
+	if len(args) != 3 && len(args) != 4 {
 		return fmt.Errorf("%s", workspaceCloneUsageText(filepath.Base(os.Args[0])))
 	}
-	workspace := args[2]
-	targetDir := args[3]
-	if err := validateAFSName("workspace", workspace); err != nil {
+
+	cfg, store, closeStore, err := openAFSStore(context.Background())
+	if err != nil {
 		return err
 	}
+	defer closeStore()
 
-	cfg, _, _, err := openAFSStore(context.Background())
+	workspace := ""
+	targetDir := ""
+	if len(args) == 4 {
+		workspace = args[2]
+		targetDir = args[3]
+	} else {
+		targetDir = args[2]
+	}
+	workspace, err = resolveWorkspaceName(context.Background(), cfg, store, workspace)
 	if err != nil {
+		return err
+	}
+	if err := validateAFSName("workspace", workspace); err != nil {
 		return err
 	}
 
@@ -381,16 +394,8 @@ func cmdWorkspaceFork(args []string) error {
 		fmt.Fprint(os.Stderr, workspaceForkUsageText(filepath.Base(os.Args[0])))
 		return nil
 	}
-	if len(args) != 4 {
+	if len(args) != 3 && len(args) != 4 {
 		return fmt.Errorf("%s", workspaceForkUsageText(filepath.Base(os.Args[0])))
-	}
-	sourceWorkspace := args[2]
-	newWorkspace := args[3]
-	if err := validateAFSName("workspace", sourceWorkspace); err != nil {
-		return err
-	}
-	if err := validateAFSName("workspace", newWorkspace); err != nil {
-		return err
 	}
 
 	cfg, store, closeStore, err := openAFSStore(context.Background())
@@ -398,6 +403,25 @@ func cmdWorkspaceFork(args []string) error {
 		return err
 	}
 	defer closeStore()
+
+	sourceWorkspace := ""
+	newWorkspace := ""
+	if len(args) == 4 {
+		sourceWorkspace = args[2]
+		newWorkspace = args[3]
+	} else {
+		newWorkspace = args[2]
+	}
+	sourceWorkspace, err = resolveWorkspaceName(context.Background(), cfg, store, sourceWorkspace)
+	if err != nil {
+		return err
+	}
+	if err := validateAFSName("workspace", sourceWorkspace); err != nil {
+		return err
+	}
+	if err := validateAFSName("workspace", newWorkspace); err != nil {
+		return err
+	}
 
 	ctx := context.Background()
 	service := controlPlaneServiceFromStore(cfg, store)
@@ -418,11 +442,14 @@ func cmdWorkspaceImport(args []string) error {
 		fmt.Fprint(os.Stderr, workspaceImportUsageText(filepath.Base(os.Args[0])))
 		return nil
 	}
-	cloneAtSource := false
+	mountAtSource := false
 	importArgs := []string{"import"}
 	for _, arg := range args[2:] {
-		if arg == "--clone-at-source" || arg == "--mount-at-source" {
-			cloneAtSource = true
+		if arg == "--clone-at-source" {
+			return fmt.Errorf(`unknown flag "--clone-at-source"; use "--mount-at-source" instead`)
+		}
+		if arg == "--mount-at-source" {
+			mountAtSource = true
 			continue
 		}
 		importArgs = append(importArgs, arg)
@@ -435,19 +462,22 @@ func cmdWorkspaceImport(args []string) error {
 	if err := cmdImport(importArgs); err != nil {
 		return err
 	}
-	if !cloneAtSource {
+	if !mountAtSource {
 		return nil
 	}
 
 	workspace := importArgs[len(importArgs)-2]
-	return cloneWorkspaceAtSource(workspace, sourceDir)
+	return mountWorkspaceAtSource(workspace, sourceDir)
 }
 
-func cloneWorkspaceAtSource(workspace, sourceDir string) error {
-	cfg, _, _, err := openAFSStore(context.Background())
+func mountWorkspaceAtSource(workspace, sourceDir string) (err error) {
+	ctx := context.Background()
+
+	cfg, store, closeStore, err := openAFSStore(ctx)
 	if err != nil {
 		return err
 	}
+	defer closeStore()
 
 	targetDir, err := expandPath(sourceDir)
 	if err != nil {
@@ -460,6 +490,23 @@ func cloneWorkspaceAtSource(workspace, sourceDir string) error {
 	if !info.IsDir() {
 		return fmt.Errorf("%s is not a directory", targetDir)
 	}
+	if entry, mounted := mountTableEntry(targetDir); mounted {
+		return fmt.Errorf("mountpoint %s is already mounted by another filesystem\n  mount entry: %s", targetDir, entry)
+	}
+
+	existingState, err := loadStateForMountAtSource()
+	if err != nil {
+		return err
+	}
+
+	mountCfg, err := prepareMountedConfig(cfg, workspace, targetDir)
+	if err != nil {
+		return err
+	}
+	backend, backendName, err := backendForConfig(mountCfg)
+	if err != nil {
+		return err
+	}
 
 	backupDir := targetDir + ".pre-afs"
 	if _, err := os.Stat(backupDir); err == nil {
@@ -468,20 +515,115 @@ func cloneWorkspaceAtSource(workspace, sourceDir string) error {
 		return err
 	}
 
-	if err := os.Rename(targetDir, backupDir); err != nil {
+	prepareStep := startStep("Opening live workspace")
+	mountKey, mountedHeadSavepoint, initialized, err := seedWorkspaceMountKey(ctx, store, workspace)
+	if err != nil {
+		prepareStep.fail(err.Error())
 		return err
 	}
-	if err := materializeWorkspaceToPath(context.Background(), cfg, workspace, targetDir); err != nil {
-		_ = os.Rename(backupDir, targetDir)
+	if initialized {
+		prepareStep.succeed(workspace + " (initialized)")
+	} else {
+		prepareStep.succeed(workspace)
+	}
+
+	rollbackArchive := false
+	cleanupMountpoint := false
+	var started mountStartResult
+	defer func() {
+		if err == nil {
+			return
+		}
+		if started.PID > 0 && processAlive(started.PID) {
+			_ = terminatePID(started.PID, 2*time.Second)
+		}
+		if backend != nil {
+			_ = backend.Unmount(targetDir)
+		}
+		if cleanupMountpoint {
+			_ = os.RemoveAll(targetDir)
+			_ = os.Remove(targetDir)
+		}
+		if rollbackArchive {
+			_ = os.Rename(backupDir, targetDir)
+		}
+	}()
+
+	archiveStep := startStep("Archiving source directory")
+	if err := os.Rename(targetDir, backupDir); err != nil {
+		archiveStep.fail(err.Error())
+		return err
+	}
+	rollbackArchive = true
+	cleanupMountpoint = true
+	archiveStep.succeed(backupDir)
+
+	mountStep := startStep("Mounting workspace at source")
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		mountStep.fail(err.Error())
+		return err
+	}
+	started, err = backend.Start(mountCfg)
+	if err != nil {
+		mountStep.fail(err.Error())
+		return err
+	}
+	if err := backend.WaitForMount(mountCfg, started, 8*time.Second); err != nil {
+		mountStep.fail("timeout")
+		return fmt.Errorf("mount did not become ready: %w", err)
+	}
+	mountStep.succeed(targetDir)
+
+	st := state{
+		StartedAt:            time.Now().UTC(),
+		ManageRedis:          existingState.ManageRedis,
+		RedisPID:             existingState.RedisPID,
+		RedisAddr:            mountCfg.RedisAddr,
+		RedisDB:              mountCfg.RedisDB,
+		CurrentWorkspace:     workspace,
+		MountedHeadSavepoint: mountedHeadSavepoint,
+		MountPID:             started.PID,
+		MountBackend:         backendName,
+		ReadOnly:             mountCfg.ReadOnly,
+		MountEndpoint:        started.Endpoint,
+		Mountpoint:           mountCfg.Mountpoint,
+		RedisKey:             mountKey,
+		RedisLog:             mountCfg.RedisLog,
+		MountLog:             mountCfg.MountLog,
+		RedisServerBin:       mountCfg.RedisServerBin,
+		MountBin:             mountCfg.MountBin,
+		ArchivePath:          backupDir,
+	}
+	if err := saveState(st); err != nil {
 		return err
 	}
 
-	printBox(clr(ansiBGreen, "●")+" "+clr(ansiBold, "workspace cloned at source"), []boxRow{
+	printBox(clr(ansiBGreen, "●")+" "+clr(ansiBold, "workspace mounted at source"), []boxRow{
 		{Label: "workspace", Value: workspace},
 		{Label: "path", Value: targetDir},
 		{Label: "backup", Value: backupDir},
+		{Label: "stop", Value: filepath.Base(os.Args[0]) + " down"},
 	})
 	return nil
+}
+
+func loadStateForMountAtSource() (state, error) {
+	st, err := loadState()
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return state{}, nil
+		}
+		return state{}, err
+	}
+
+	backendName := strings.TrimSpace(st.MountBackend)
+	if backendName == "" {
+		backendName = mountBackendNone
+	}
+	if backendName != mountBackendNone || strings.TrimSpace(st.ArchivePath) != "" {
+		return state{}, fmt.Errorf("AFS already has an active mounted filesystem state; run '%s down' first", filepath.Base(os.Args[0]))
+	}
+	return st, nil
 }
 
 func materializeWorkspaceToPath(ctx context.Context, cfg config, workspace, targetDir string) error {
@@ -518,12 +660,8 @@ func cmdCheckpointList(args []string) error {
 		fmt.Fprint(os.Stderr, checkpointListUsageText(filepath.Base(os.Args[0])))
 		return nil
 	}
-	if len(args) != 3 {
+	if len(args) != 2 && len(args) != 3 {
 		return fmt.Errorf("%s", checkpointListUsageText(filepath.Base(os.Args[0])))
-	}
-	workspace := args[2]
-	if err := validateAFSName("workspace", workspace); err != nil {
-		return err
 	}
 
 	cfg, store, closeStore, err := openAFSStore(context.Background())
@@ -531,6 +669,18 @@ func cmdCheckpointList(args []string) error {
 		return err
 	}
 	defer closeStore()
+
+	workspace := ""
+	if len(args) == 3 {
+		workspace = args[2]
+	}
+	workspace, err = resolveWorkspaceName(context.Background(), cfg, store, workspace)
+	if err != nil {
+		return err
+	}
+	if err := validateAFSName("workspace", workspace); err != nil {
+		return err
+	}
 
 	service := controlPlaneServiceFromStore(cfg, store)
 	checkpoints, err := service.ListCheckpoints(context.Background(), workspace, 100)
@@ -541,7 +691,7 @@ func cmdCheckpointList(args []string) error {
 	for _, meta := range checkpoints {
 		rows = append(rows, boxRow{
 			Label: meta.Name,
-			Value: fmt.Sprintf("%s · %s", meta.CreatedAt, formatBytes(meta.TotalBytes)),
+			Value: fmt.Sprintf("%s · %s", formatDisplayTimestamp(meta.CreatedAt), formatBytes(meta.TotalBytes)),
 		})
 	}
 	if len(rows) == 0 {
@@ -556,19 +706,8 @@ func cmdCheckpointCreate(args []string) error {
 		fmt.Fprint(os.Stderr, checkpointCreateUsageText(filepath.Base(os.Args[0])))
 		return nil
 	}
-	if len(args) != 3 && len(args) != 4 {
+	if len(args) != 2 && len(args) != 3 && len(args) != 4 {
 		return fmt.Errorf("%s", checkpointCreateUsageText(filepath.Base(os.Args[0])))
-	}
-	workspace := args[2]
-	checkpointID := generatedSavepointName()
-	if len(args) == 4 {
-		checkpointID = args[3]
-	}
-	if err := validateAFSName("workspace", workspace); err != nil {
-		return err
-	}
-	if err := validateAFSName("checkpoint", checkpointID); err != nil {
-		return err
 	}
 
 	cfg, store, closeStore, err := openAFSStore(context.Background())
@@ -577,7 +716,31 @@ func cmdCheckpointCreate(args []string) error {
 	}
 	defer closeStore()
 
-	saved, err := saveAFSWorkspace(context.Background(), cfg, store, workspace, checkpointID, false)
+	workspace := ""
+	checkpointID := generatedSavepointName()
+	switch len(args) {
+	case 4:
+		workspace = args[2]
+		checkpointID = args[3]
+	case 3:
+		if hasCurrentWorkspaceSelection(cfg) {
+			checkpointID = args[2]
+		} else {
+			workspace = args[2]
+		}
+	}
+	workspace, err = resolveWorkspaceName(context.Background(), cfg, store, workspace)
+	if err != nil {
+		return err
+	}
+	if err := validateAFSName("workspace", workspace); err != nil {
+		return err
+	}
+	if err := validateAFSName("checkpoint", checkpointID); err != nil {
+		return err
+	}
+
+	saved, err := saveAFSWorkspaceOrLiveRoot(context.Background(), cfg, store, workspace, checkpointID, false)
 	if err != nil {
 		return err
 	}
@@ -598,11 +761,28 @@ func cmdCheckpointRestore(args []string) error {
 		fmt.Fprint(os.Stderr, checkpointRestoreUsageText(filepath.Base(os.Args[0])))
 		return nil
 	}
-	if len(args) != 4 {
+	if len(args) != 3 && len(args) != 4 {
 		return fmt.Errorf("%s", checkpointRestoreUsageText(filepath.Base(os.Args[0])))
 	}
-	workspace := args[2]
-	checkpointID := args[3]
+
+	cfg, store, closeStore, err := openAFSStore(context.Background())
+	if err != nil {
+		return err
+	}
+	defer closeStore()
+
+	workspace := ""
+	checkpointID := ""
+	if len(args) == 4 {
+		workspace = args[2]
+		checkpointID = args[3]
+	} else {
+		checkpointID = args[2]
+	}
+	workspace, err = resolveWorkspaceName(context.Background(), cfg, store, workspace)
+	if err != nil {
+		return err
+	}
 	if err := validateAFSName("workspace", workspace); err != nil {
 		return err
 	}
@@ -644,6 +824,10 @@ func restoreCheckpoint(ctx context.Context, workspace, checkpointID string) erro
 	return nil
 }
 
+func hasCurrentWorkspaceSelection(cfg config) bool {
+	return selectedWorkspaceName(cfg) != ""
+}
+
 func workspaceUsageText(bin string) string {
 	return fmt.Sprintf(`Usage:
   %s workspace <subcommand>
@@ -654,10 +838,10 @@ Subcommands:
   current                                      Show the current workspace
   use <workspace>                              Set the current workspace
   run [workspace] [--readonly] -- <command...> Materialize and run in a workspace cwd
-  clone <workspace> <directory>               Clone a workspace into a local directory
-  fork <source-workspace> <new-workspace>     Fork a workspace at its current head
+  clone [workspace] <directory>                Clone a workspace into a local directory
+  fork [source-workspace] <new-workspace>      Fork a workspace at its current head
   delete <workspace>...                       Delete workspaces and local materialized state
-  import [--force] [--clone-at-source] <workspace> <directory>
+  import [--force] [--mount-at-source] <workspace> <directory>
                                                Import a local directory into a workspace
 
 Examples:
@@ -722,18 +906,22 @@ Set the current workspace AFS will use when a workspace argument is omitted.
 
 func workspaceCloneUsageText(bin string) string {
 	return fmt.Sprintf(`Usage:
-  %s workspace clone <workspace> <directory>
+  %s workspace clone [workspace] <directory>
 
 Clone a workspace into a local directory at its current saved head.
 The destination must not already contain files.
+
+If [workspace] is omitted, AFS uses the current workspace.
 `, bin)
 }
 
 func workspaceForkUsageText(bin string) string {
 	return fmt.Sprintf(`Usage:
-  %s workspace fork <source-workspace> <new-workspace>
+  %s workspace fork [source-workspace] <new-workspace>
 
 Create a new workspace from the source workspace's current saved head.
+
+If [source-workspace] is omitted, AFS uses the current workspace.
 `, bin)
 }
 
@@ -747,14 +935,14 @@ Delete one or more workspaces from Redis and remove their local materialized sta
 
 func workspaceImportUsageText(bin string) string {
 	return fmt.Sprintf(`Usage:
-  %s workspace import [--force] [--clone-at-source] <workspace> <directory>
+  %s workspace import [--force] [--mount-at-source] <workspace> <directory>
 
 Import a local directory into a workspace.
 
 Options:
   --force            Replace an existing workspace
-  --clone-at-source  Replace the source directory with a materialized workspace copy
-                     and keep the original directory as <directory>.pre-afs
+  --mount-at-source  Archive the source directory to <directory>.pre-afs and
+                     mount the imported workspace at the original path
 `, bin)
 }
 
@@ -763,40 +951,44 @@ func checkpointUsageText(bin string) string {
   %s checkpoint <subcommand>
 
 Subcommands:
-  list <workspace>                     List checkpoints for a workspace
-  create <workspace> [checkpoint]     Create a checkpoint from the local working copy
-  restore <workspace> <checkpoint>    Restore a workspace to a checkpoint
+  list [workspace]                     List checkpoints for a workspace
+  create [workspace] [checkpoint]     Create a checkpoint from the current workspace state
+  restore [workspace] <checkpoint>    Restore a workspace to a checkpoint
 
 Examples:
   %s checkpoint list demo
   %s checkpoint create demo before-refactor
+  %s checkpoint create before-refactor
   %s checkpoint restore demo initial
 
 Run '%s checkpoint <subcommand> --help' for details.
-`, bin, bin, bin, bin, bin)
+`, bin, bin, bin, bin, bin, bin)
 }
 
 func checkpointListUsageText(bin string) string {
 	return fmt.Sprintf(`Usage:
-  %s checkpoint list <workspace>
+  %s checkpoint list [workspace]
 
 List checkpoints for a workspace, newest first.
+If [workspace] is omitted, AFS uses the current workspace.
 `, bin)
 }
 
 func checkpointCreateUsageText(bin string) string {
 	return fmt.Sprintf(`Usage:
-  %s checkpoint create <workspace> [checkpoint]
+  %s checkpoint create [workspace] [checkpoint]
 
-Create a checkpoint from the workspace's current local working copy.
+Create a checkpoint from the workspace's current state.
+If [workspace] is omitted, AFS uses the current workspace.
 If [checkpoint] is omitted, AFS generates a timestamped name.
 `, bin)
 }
 
 func checkpointRestoreUsageText(bin string) string {
 	return fmt.Sprintf(`Usage:
-  %s checkpoint restore <workspace> <checkpoint>
+  %s checkpoint restore [workspace] <checkpoint>
 
 Restore the workspace working copy to the selected checkpoint.
+If [workspace] is omitted, AFS uses the current workspace.
 `, bin)
 }

--- a/cli/workspace_checkpoint_commands_test.go
+++ b/cli/workspace_checkpoint_commands_test.go
@@ -6,8 +6,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/rowantrollope/agent-filesystem/cli/internal/controlplane"
+	"github.com/rowantrollope/agent-filesystem/mount/client"
 )
 
 func TestWorkspaceCommandsImportRunCloneForkListAndDelete(t *testing.T) {
@@ -171,6 +174,368 @@ func TestCheckpointCommandsCreateAndRestore(t *testing.T) {
 	if !strings.Contains(listOutput, "initial") || !strings.Contains(listOutput, "after-edit") {
 		t.Fatalf("cmdCheckpoint(list) output = %q, want both checkpoint names", listOutput)
 	}
+	if strings.Contains(listOutput, "T") || strings.Contains(listOutput, "Z") {
+		t.Fatalf("cmdCheckpoint(list) output = %q, want human-readable timestamps instead of raw RFC3339", listOutput)
+	}
+}
+
+func TestCheckpointCreateUsesLiveWorkspaceWhenNoLocalTreeExists(t *testing.T) {
+	t.Helper()
+
+	mr := miniredis.RunT(t)
+
+	cfg := defaultConfig()
+	cfg.UseExistingRedis = true
+	cfg.RedisAddr = mr.Addr()
+	cfg.MountBackend = "nfs"
+	cfg.NFSBin = "/usr/bin/true"
+	cfg.WorkRoot = t.TempDir()
+	saveTempConfig(t, cfg)
+
+	sourceDir := t.TempDir()
+	writeTestFile(t, filepath.Join(sourceDir, "main.go"), "package main\n")
+
+	if err := cmdWorkspace([]string{"workspace", "import", "repo", sourceDir}); err != nil {
+		t.Fatalf("cmdWorkspace(import) returned error: %v", err)
+	}
+
+	loadedCfg, store, closeStore, err := openAFSStore(context.Background())
+	if err != nil {
+		t.Fatalf("openAFSStore() returned error: %v", err)
+	}
+	defer closeStore()
+
+	rootKey, _, _, err := seedWorkspaceMountKey(context.Background(), store, "repo")
+	if err != nil {
+		t.Fatalf("seedWorkspaceMountKey() returned error: %v", err)
+	}
+	if err := client.New(store.rdb, rootKey).Echo(context.Background(), "/mounted.txt", []byte("hello from live root\n")); err != nil {
+		t.Fatalf("Echo(/mounted.txt) returned error: %v", err)
+	}
+
+	if err := cmdCheckpoint([]string{"checkpoint", "create", "repo", "after-mounted"}); err != nil {
+		t.Fatalf("cmdCheckpoint(create) returned error: %v", err)
+	}
+
+	workspaceMeta, err := store.getWorkspaceMeta(context.Background(), "repo")
+	if err != nil {
+		t.Fatalf("getWorkspaceMeta(repo) returned error: %v", err)
+	}
+	if workspaceMeta.HeadSavepoint != "after-mounted" {
+		t.Fatalf("HeadSavepoint = %q, want %q", workspaceMeta.HeadSavepoint, "after-mounted")
+	}
+
+	manifest, err := store.getManifest(context.Background(), "repo", "after-mounted")
+	if err != nil {
+		t.Fatalf("getManifest(after-mounted) returned error: %v", err)
+	}
+	if _, ok := manifest.Entries["/mounted.txt"]; !ok {
+		t.Fatal("expected /mounted.txt in after-mounted checkpoint")
+	}
+
+	if _, err := os.Stat(afsWorkspaceTreePath(loadedCfg, "repo")); !os.IsNotExist(err) {
+		t.Fatalf("expected no local workspace tree, stat err = %v", err)
+	}
+}
+
+func TestCheckpointCreatePrefersMountedLiveWorkspaceOverLocalTree(t *testing.T) {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", homeDir); err != nil {
+		t.Fatalf("Setenv(HOME) returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", origHome)
+	})
+
+	mr := miniredis.RunT(t)
+
+	cfg := defaultConfig()
+	cfg.UseExistingRedis = true
+	cfg.RedisAddr = mr.Addr()
+	cfg.MountBackend = "nfs"
+	cfg.NFSBin = "/usr/bin/true"
+	cfg.WorkRoot = t.TempDir()
+	saveTempConfig(t, cfg)
+
+	sourceDir := t.TempDir()
+	writeTestFile(t, filepath.Join(sourceDir, "main.go"), "package main\n")
+
+	if err := cmdWorkspace([]string{"workspace", "import", "repo", sourceDir}); err != nil {
+		t.Fatalf("cmdWorkspace(import) returned error: %v", err)
+	}
+	if err := cmdWorkspace([]string{"workspace", "run", "repo", "--", "/bin/sh", "-c", "true"}); err != nil {
+		t.Fatalf("cmdWorkspace(run) returned error: %v", err)
+	}
+
+	_, store, closeStore, err := openAFSStore(context.Background())
+	if err != nil {
+		t.Fatalf("openAFSStore() returned error: %v", err)
+	}
+	defer closeStore()
+
+	rootKey, _, _, err := seedWorkspaceMountKey(context.Background(), store, "repo")
+	if err != nil {
+		t.Fatalf("seedWorkspaceMountKey() returned error: %v", err)
+	}
+	if err := client.New(store.rdb, rootKey).Echo(context.Background(), "/newfile.txt", []byte("from mounted workspace\n")); err != nil {
+		t.Fatalf("Echo(/newfile.txt) returned error: %v", err)
+	}
+
+	st := state{
+		StartedAt:            time.Now().UTC(),
+		ManageRedis:          false,
+		RedisAddr:            cfg.RedisAddr,
+		RedisDB:              cfg.RedisDB,
+		CurrentWorkspace:     "repo",
+		MountedHeadSavepoint: "initial",
+		MountBackend:         mountBackendNFS,
+		Mountpoint:           filepath.Join(t.TempDir(), "mount"),
+		RedisKey:             workspaceRedisKey("repo"),
+	}
+	if err := saveState(st); err != nil {
+		t.Fatalf("saveState() returned error: %v", err)
+	}
+
+	if err := cmdCheckpoint([]string{"checkpoint", "create", "repo", "after-mounted-live"}); err != nil {
+		t.Fatalf("cmdCheckpoint(create) returned error: %v", err)
+	}
+
+	workspaceMeta, err := store.getWorkspaceMeta(context.Background(), "repo")
+	if err != nil {
+		t.Fatalf("getWorkspaceMeta(repo) returned error: %v", err)
+	}
+	if workspaceMeta.HeadSavepoint != "after-mounted-live" {
+		t.Fatalf("HeadSavepoint = %q, want %q", workspaceMeta.HeadSavepoint, "after-mounted-live")
+	}
+
+	manifest, err := store.getManifest(context.Background(), "repo", "after-mounted-live")
+	if err != nil {
+		t.Fatalf("getManifest(after-mounted-live) returned error: %v", err)
+	}
+	entry, ok := manifest.Entries["/newfile.txt"]
+	if !ok {
+		t.Fatal("expected /newfile.txt in after-mounted-live checkpoint")
+	}
+	data, err := controlplane.ManifestEntryData(entry, func(blobID string) ([]byte, error) {
+		return store.getBlob(context.Background(), "repo", blobID)
+	})
+	if err != nil {
+		t.Fatalf("ManifestEntryData(/newfile.txt) returned error: %v", err)
+	}
+	if string(data) != "from mounted workspace\n" {
+		t.Fatalf("newfile.txt = %q, want %q", string(data), "from mounted workspace\n")
+	}
+}
+
+func TestCheckpointCommandsUseCurrentWorkspaceWhenOmitted(t *testing.T) {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", homeDir); err != nil {
+		t.Fatalf("Setenv(HOME) returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", origHome)
+	})
+
+	mr := miniredis.RunT(t)
+
+	cfg := defaultConfig()
+	cfg.UseExistingRedis = true
+	cfg.RedisAddr = mr.Addr()
+	cfg.MountBackend = "nfs"
+	cfg.NFSBin = "/usr/bin/true"
+	cfg.WorkRoot = t.TempDir()
+	cfg.CurrentWorkspace = "repo"
+	saveTempConfig(t, cfg)
+
+	sourceDir := t.TempDir()
+	writeTestFile(t, filepath.Join(sourceDir, "main.go"), "package main\n")
+
+	if err := cmdWorkspace([]string{"workspace", "import", "repo", sourceDir}); err != nil {
+		t.Fatalf("cmdWorkspace(import) returned error: %v", err)
+	}
+
+	_, store, closeStore, err := openAFSStore(context.Background())
+	if err != nil {
+		t.Fatalf("openAFSStore() returned error: %v", err)
+	}
+	defer closeStore()
+
+	rootKey, _, _, err := seedWorkspaceMountKey(context.Background(), store, "repo")
+	if err != nil {
+		t.Fatalf("seedWorkspaceMountKey() returned error: %v", err)
+	}
+	if err := client.New(store.rdb, rootKey).Echo(context.Background(), "/current-only.txt", []byte("via current workspace\n")); err != nil {
+		t.Fatalf("Echo(/current-only.txt) returned error: %v", err)
+	}
+
+	st := state{
+		StartedAt:            time.Now().UTC(),
+		ManageRedis:          false,
+		RedisAddr:            cfg.RedisAddr,
+		RedisDB:              cfg.RedisDB,
+		CurrentWorkspace:     "repo",
+		MountedHeadSavepoint: "initial",
+		MountBackend:         mountBackendNFS,
+		Mountpoint:           filepath.Join(t.TempDir(), "mount"),
+		RedisKey:             workspaceRedisKey("repo"),
+	}
+	if err := saveState(st); err != nil {
+		t.Fatalf("saveState() returned error: %v", err)
+	}
+
+	if err := cmdCheckpoint([]string{"checkpoint", "create", "current-save"}); err != nil {
+		t.Fatalf("cmdCheckpoint(create current-save) returned error: %v", err)
+	}
+
+	listOutput, err := captureStdout(t, func() error {
+		return cmdCheckpoint([]string{"checkpoint", "list"})
+	})
+	if err != nil {
+		t.Fatalf("cmdCheckpoint(list) returned error: %v", err)
+	}
+	if !strings.Contains(listOutput, "current-save") {
+		t.Fatalf("cmdCheckpoint(list) output = %q, want current-save", listOutput)
+	}
+
+	if err := cmdCheckpoint([]string{"checkpoint", "restore", "initial"}); err != nil {
+		t.Fatalf("cmdCheckpoint(restore initial) returned error: %v", err)
+	}
+
+	workspaceMeta, err := store.getWorkspaceMeta(context.Background(), "repo")
+	if err != nil {
+		t.Fatalf("getWorkspaceMeta(repo) returned error: %v", err)
+	}
+	if workspaceMeta.HeadSavepoint != "initial" {
+		t.Fatalf("HeadSavepoint = %q, want %q", workspaceMeta.HeadSavepoint, "initial")
+	}
+}
+
+func TestCheckpointCreateUsesActiveMountedWorkspaceWhenConfigUnset(t *testing.T) {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", homeDir); err != nil {
+		t.Fatalf("Setenv(HOME) returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", origHome)
+	})
+
+	mr := miniredis.RunT(t)
+
+	cfg := defaultConfig()
+	cfg.UseExistingRedis = true
+	cfg.RedisAddr = mr.Addr()
+	cfg.MountBackend = "nfs"
+	cfg.NFSBin = "/usr/bin/true"
+	cfg.WorkRoot = t.TempDir()
+	saveTempConfig(t, cfg)
+
+	sourceDir := t.TempDir()
+	writeTestFile(t, filepath.Join(sourceDir, "main.go"), "package main\n")
+
+	if err := cmdWorkspace([]string{"workspace", "import", "repo", sourceDir}); err != nil {
+		t.Fatalf("cmdWorkspace(import) returned error: %v", err)
+	}
+
+	_, store, closeStore, err := openAFSStore(context.Background())
+	if err != nil {
+		t.Fatalf("openAFSStore() returned error: %v", err)
+	}
+	defer closeStore()
+
+	rootKey, _, _, err := seedWorkspaceMountKey(context.Background(), store, "repo")
+	if err != nil {
+		t.Fatalf("seedWorkspaceMountKey() returned error: %v", err)
+	}
+	if err := client.New(store.rdb, rootKey).Echo(context.Background(), "/active-state.txt", []byte("from active state\n")); err != nil {
+		t.Fatalf("Echo(/active-state.txt) returned error: %v", err)
+	}
+
+	if err := saveState(state{
+		StartedAt:            time.Now().UTC(),
+		ManageRedis:          false,
+		RedisAddr:            cfg.RedisAddr,
+		RedisDB:              cfg.RedisDB,
+		CurrentWorkspace:     "repo",
+		MountedHeadSavepoint: "initial",
+		MountBackend:         mountBackendNFS,
+		Mountpoint:           filepath.Join(t.TempDir(), "mount"),
+		RedisKey:             workspaceRedisKey("repo"),
+	}); err != nil {
+		t.Fatalf("saveState() returned error: %v", err)
+	}
+
+	if err := cmdCheckpoint([]string{"checkpoint", "create", "active-state-save"}); err != nil {
+		t.Fatalf("cmdCheckpoint(create active-state-save) returned error: %v", err)
+	}
+
+	workspaceMeta, err := store.getWorkspaceMeta(context.Background(), "repo")
+	if err != nil {
+		t.Fatalf("getWorkspaceMeta(repo) returned error: %v", err)
+	}
+	if workspaceMeta.HeadSavepoint != "active-state-save" {
+		t.Fatalf("HeadSavepoint = %q, want %q", workspaceMeta.HeadSavepoint, "active-state-save")
+	}
+}
+
+func TestWorkspaceCloneAndForkUseCurrentWorkspaceWhenOmitted(t *testing.T) {
+	t.Helper()
+
+	mr := miniredis.RunT(t)
+
+	cfg := defaultConfig()
+	cfg.UseExistingRedis = true
+	cfg.RedisAddr = mr.Addr()
+	cfg.MountBackend = "nfs"
+	cfg.NFSBin = "/usr/bin/true"
+	cfg.WorkRoot = t.TempDir()
+	cfg.CurrentWorkspace = "repo"
+	saveTempConfig(t, cfg)
+
+	sourceDir := t.TempDir()
+	writeTestFile(t, filepath.Join(sourceDir, "main.go"), "package main\n")
+
+	if err := cmdWorkspace([]string{"workspace", "import", "repo", sourceDir}); err != nil {
+		t.Fatalf("cmdWorkspace(import) returned error: %v", err)
+	}
+
+	clonedDir := filepath.Join(t.TempDir(), "repo-clone")
+	if err := cmdWorkspace([]string{"workspace", "clone", clonedDir}); err != nil {
+		t.Fatalf("cmdWorkspace(clone omitted workspace) returned error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(clonedDir, "main.go")); err != nil {
+		t.Fatalf("expected cloned directory to contain main.go: %v", err)
+	}
+
+	if err := cmdWorkspace([]string{"workspace", "fork", "repo-copy"}); err != nil {
+		t.Fatalf("cmdWorkspace(fork omitted source) returned error: %v", err)
+	}
+
+	loadedCfg, store, closeStore, err := openAFSStore(context.Background())
+	if err != nil {
+		t.Fatalf("openAFSStore() returned error: %v", err)
+	}
+	defer closeStore()
+
+	exists, err := store.workspaceExists(context.Background(), "repo-copy")
+	if err != nil {
+		t.Fatalf("workspaceExists(repo-copy) returned error: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected repo-copy workspace to exist after fork")
+	}
+
+	if loadedCfg.CurrentWorkspace != "repo" {
+		t.Fatalf("CurrentWorkspace = %q, want %q", loadedCfg.CurrentWorkspace, "repo")
+	}
 }
 
 func TestWorkspaceRunRejectsLegacyFlag(t *testing.T) {
@@ -182,5 +547,49 @@ func TestWorkspaceRunRejectsLegacyFlag(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `unknown flag "--session"`) {
 		t.Fatalf("cmdWorkspace(run) error = %q, want legacy --session rejection", err)
+	}
+}
+
+func TestWorkspaceImportRejectsRemovedCloneAtSourceFlag(t *testing.T) {
+	t.Helper()
+
+	err := cmdWorkspace([]string{"workspace", "import", "--clone-at-source", "repo", "/tmp/repo"})
+	if err == nil {
+		t.Fatal("cmdWorkspace(import) returned nil error, want removed flag rejection")
+	}
+	if !strings.Contains(err.Error(), "--mount-at-source") {
+		t.Fatalf("cmdWorkspace(import) error = %q, want replacement flag guidance", err)
+	}
+}
+
+func TestLoadStateForMountAtSourceRejectsExistingMountedState(t *testing.T) {
+	t.Helper()
+
+	homeDir := t.TempDir()
+	origHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", homeDir); err != nil {
+		t.Fatalf("Setenv(HOME) returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Setenv("HOME", origHome)
+	})
+
+	st := state{
+		StartedAt:        time.Now().UTC(),
+		CurrentWorkspace: "repo",
+		MountBackend:     mountBackendNFS,
+		Mountpoint:       filepath.Join(t.TempDir(), "mount"),
+		ArchivePath:      filepath.Join(t.TempDir(), "mount.pre-afs"),
+	}
+	if err := saveState(st); err != nil {
+		t.Fatalf("saveState() returned error: %v", err)
+	}
+
+	_, err := loadStateForMountAtSource()
+	if err == nil {
+		t.Fatal("loadStateForMountAtSource() returned nil error, want running mount rejection")
+	}
+	if !strings.Contains(err.Error(), "run '") || !strings.Contains(err.Error(), "down' first") {
+		t.Fatalf("loadStateForMountAtSource() error = %q, want afs down guidance", err)
 	}
 }

--- a/cli/workspace_mount_bridge.go
+++ b/cli/workspace_mount_bridge.go
@@ -5,11 +5,9 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
-	"github.com/redis/go-redis/v9"
 	"github.com/rowantrollope/agent-filesystem/mount/client"
 )
 
@@ -25,7 +23,7 @@ var mountedArtifactNames = map[string]struct{}{
 }
 
 func mountRedisKeyForWorkspace(workspace string) string {
-	return "afs.mount." + workspace
+	return workspaceRedisKey(workspace)
 }
 
 func ensureMountWorkspace(ctx context.Context, cfg config, store *afsStore) (string, bool, error) {
@@ -50,53 +48,23 @@ func ensureMountWorkspace(ctx context.Context, cfg config, store *afsStore) (str
 	return workspace, true, nil
 }
 
-func seedWorkspaceMountKey(ctx context.Context, cfg config, store *afsStore, rdb *redis.Client, workspace string) (string, string, error) {
-	workspaceMeta, _, err := ensureMaterializedWorkspace(ctx, store, cfg, workspace)
+func seedWorkspaceMountKey(ctx context.Context, store *afsStore, workspace string) (string, string, bool, error) {
+	mountKey, headSavepoint, initialized, err := store.ensureWorkspaceRoot(ctx, workspace)
 	if err != nil {
-		return "", "", err
+		return "", "", false, err
 	}
-
-	treePath := afsWorkspaceTreePath(cfg, workspace)
-	mountKey := mountRedisKeyForWorkspace(workspace)
-	if err := syncDirectoryToAFSKey(ctx, rdb, mountKey, treePath); err != nil {
-		return "", "", err
-	}
-	return mountKey, workspaceMeta.HeadSavepoint, nil
+	ensureWorkspaceSearchIndex(ctx, store.rdb, mountKey)
+	return mountKey, headSavepoint, initialized, nil
 }
 
-func syncDirectoryToAFSKey(ctx context.Context, rdb *redis.Client, fsKey, sourceDir string) error {
-	if err := deleteNamespace(ctx, rdb, fsKey); err != nil {
-		return err
-	}
-	fsClient := client.New(rdb, fsKey)
-	if _, _, _, _, _, err := importDirectory(ctx, fsClient, sourceDir, nil, nil); err != nil {
-		return err
-	}
-
-	rootInfo, err := os.Stat(sourceDir)
-	if err != nil {
-		return err
-	}
-	return applyMetadata(ctx, client.New(rdb, fsKey), "/", rootInfo)
-}
-
-func syncMountedWorkspaceBack(ctx context.Context, cfg config, store *afsStore, rdb *redis.Client, workspace, expectedHead string) (bool, error) {
-	savepointID := generatedSavepointName()
-	mountKey := mountRedisKeyForWorkspace(workspace)
-
-	mountedManifest, blobs, stats, err := buildManifestFromAFS(ctx, client.New(rdb, mountKey), workspace, savepointID)
+func saveWorkspaceRootCheckpoint(ctx context.Context, store *afsStore, workspace, expectedHead, savepointID string) (bool, error) {
+	rootManifest, blobs, stats, err := buildManifestFromAFS(ctx, client.New(store.rdb, workspaceRedisKey(workspace)), workspace, savepointID)
 	if err != nil {
 		return false, err
 	}
 
-	saved, err := saveAFSManifest(ctx, store, workspace, expectedHead, savepointID, mountedManifest, blobs, stats)
+	saved, err := saveAFSManifest(ctx, store, workspace, expectedHead, savepointID, rootManifest, blobs, stats)
 	if err != nil {
-		if err == errAFSWorkspaceConflict {
-			return false, fmt.Errorf("workspace %q moved while it was mounted; inspect it before stopping AFS", workspace)
-		}
-		return false, err
-	}
-	if err := materializeWorkspace(ctx, store, cfg, workspace); err != nil {
 		return false, err
 	}
 	return saved, nil

--- a/cli/workspace_mount_bridge_test.go
+++ b/cli/workspace_mount_bridge_test.go
@@ -2,13 +2,15 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
-	"strings"
+	"strconv"
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/redis/go-redis/v9"
+	"github.com/rowantrollope/agent-filesystem/cli/internal/controlplane"
 	"github.com/rowantrollope/agent-filesystem/mount/client"
 )
 
@@ -45,40 +47,65 @@ func TestEnsureMountWorkspaceCreatesMissingCurrentWorkspace(t *testing.T) {
 	}
 }
 
-func TestSeedWorkspaceMountKeyUsesCurrentWorkspaceTree(t *testing.T) {
+func TestSeedWorkspaceMountKeyUsesWorkspaceHeadInsteadOfLocalTree(t *testing.T) {
 	t.Helper()
 
-	cfg, treePath, store, closeStore := importAFSWorkspaceForTest(t)
+	cfg, store, closeStore := seedWorkspaceMountBridgeFixture(t)
 	defer closeStore()
 
-	writeTestFile(t, filepath.Join(treePath, "main.go"), "package dirty\n")
+	writeTestFile(t, filepath.Join(afsWorkspaceTreePath(cfg, "repo"), "main.go"), "package local\n")
 
 	ctx := context.Background()
-	mountKey, head, err := seedWorkspaceMountKey(ctx, cfg, store, store.rdb, "repo")
+	mountKey, head, initialized, err := seedWorkspaceMountKey(ctx, store, "repo")
 	if err != nil {
 		t.Fatalf("seedWorkspaceMountKey() returned error: %v", err)
 	}
+	if !initialized {
+		t.Fatal("expected first workspace mount open to initialize the live workspace root")
+	}
 	if head != "initial" {
 		t.Fatalf("head = %q, want %q", head, "initial")
+	}
+	if mountKey != workspaceRedisKey("repo") {
+		t.Fatalf("mountKey = %q, want %q", mountKey, workspaceRedisKey("repo"))
 	}
 
 	data, err := client.New(store.rdb, mountKey).Cat(ctx, "/main.go")
 	if err != nil {
 		t.Fatalf("Cat(/main.go) returned error: %v", err)
 	}
-	if string(data) != "package dirty\n" {
-		t.Fatalf("mounted main.go = %q, want %q", string(data), "package dirty\n")
+	if string(data) != "package main\n" {
+		t.Fatalf("mounted main.go = %q, want %q", string(data), "package main\n")
+	}
+
+	st, err := client.New(store.rdb, mountKey).Stat(ctx, "/main.go")
+	if err != nil {
+		t.Fatalf("Stat(/main.go) returned error: %v", err)
+	}
+	if st == nil || st.Inode == 0 {
+		t.Fatalf("expected inode for /main.go, got %+v", st)
+	}
+
+	vals, err := store.rdb.HGetAll(ctx, "afs:{"+mountKey+"}:inode:"+strconv.FormatUint(st.Inode, 10)).Result()
+	if err != nil {
+		t.Fatalf("HGetAll(main.go inode) returned error: %v", err)
+	}
+	if vals["path"] != "/main.go" {
+		t.Fatalf("path = %q, want %q", vals["path"], "/main.go")
+	}
+	if vals["path_ancestors"] != "/main.go" {
+		t.Fatalf("path_ancestors = %q, want %q", vals["path_ancestors"], "/main.go")
 	}
 }
 
 func TestSeedWorkspaceMountKeyUsesCanonicalAFSKeysOnly(t *testing.T) {
 	t.Helper()
 
-	cfg, _, store, closeStore := importAFSWorkspaceForTest(t)
+	_, store, closeStore := seedWorkspaceMountBridgeFixture(t)
 	defer closeStore()
 
 	ctx := context.Background()
-	mountKey, _, err := seedWorkspaceMountKey(ctx, cfg, store, store.rdb, "repo")
+	mountKey, _, _, err := seedWorkspaceMountKey(ctx, store, "repo")
 	if err != nil {
 		t.Fatalf("seedWorkspaceMountKey() returned error: %v", err)
 	}
@@ -100,9 +127,6 @@ func TestSeedWorkspaceMountKeyUsesCanonicalAFSKeysOnly(t *testing.T) {
 	}
 
 	for _, key := range keys {
-		if strings.HasPrefix(key, "afs:{"+mountKey+"}:children:") {
-			t.Fatalf("unexpected legacy children key: %s", key)
-		}
 		if key == "afs:{"+mountKey+"}:inode:/" {
 			t.Fatalf("unexpected legacy path-keyed root inode key: %s", key)
 		}
@@ -117,14 +141,57 @@ func TestSeedWorkspaceMountKeyUsesCanonicalAFSKeysOnly(t *testing.T) {
 	}
 }
 
-func TestSyncMountedWorkspaceBackSavesMountChangesIntoWorkspace(t *testing.T) {
+func TestSeedWorkspaceMountKeyKeepsExistingLiveWorkspaceRoot(t *testing.T) {
 	t.Helper()
 
-	cfg, _, store, closeStore := importAFSWorkspaceForTest(t)
+	_, store, closeStore := seedWorkspaceMountBridgeFixture(t)
 	defer closeStore()
 
 	ctx := context.Background()
-	mountKey, head, err := seedWorkspaceMountKey(ctx, cfg, store, store.rdb, "repo")
+	mountKey, _, initialized, err := seedWorkspaceMountKey(ctx, store, "repo")
+	if err != nil {
+		t.Fatalf("seedWorkspaceMountKey() returned error: %v", err)
+	}
+	if !initialized {
+		t.Fatal("expected first workspace mount open to initialize the live workspace root")
+	}
+
+	fsClient := client.New(store.rdb, mountKey)
+	if err := fsClient.Echo(ctx, "/live.txt", []byte("live change\n")); err != nil {
+		t.Fatalf("Echo(/live.txt) returned error: %v", err)
+	}
+
+	secondKey, secondHead, initializedAgain, err := seedWorkspaceMountKey(ctx, store, "repo")
+	if err != nil {
+		t.Fatalf("second seedWorkspaceMountKey() returned error: %v", err)
+	}
+	if initializedAgain {
+		t.Fatal("expected repeated workspace mount open to reuse the live workspace root")
+	}
+	if secondKey != mountKey {
+		t.Fatalf("second mountKey = %q, want %q", secondKey, mountKey)
+	}
+	if secondHead != "initial" {
+		t.Fatalf("second head = %q, want %q", secondHead, "initial")
+	}
+
+	data, err := fsClient.Cat(ctx, "/live.txt")
+	if err != nil {
+		t.Fatalf("Cat(/live.txt) returned error: %v", err)
+	}
+	if string(data) != "live change\n" {
+		t.Fatalf("live.txt = %q, want %q", string(data), "live change\n")
+	}
+}
+
+func TestSaveWorkspaceRootCheckpointSavesLiveWorkspaceChangesIntoWorkspace(t *testing.T) {
+	t.Helper()
+
+	cfg, store, closeStore := seedWorkspaceMountBridgeFixture(t)
+	defer closeStore()
+
+	ctx := context.Background()
+	mountKey, head, _, err := seedWorkspaceMountKey(ctx, store, "repo")
 	if err != nil {
 		t.Fatalf("seedWorkspaceMountKey() returned error: %v", err)
 	}
@@ -134,9 +201,9 @@ func TestSyncMountedWorkspaceBackSavesMountChangesIntoWorkspace(t *testing.T) {
 		t.Fatalf("Echo(/mounted.txt) returned error: %v", err)
 	}
 
-	saved, err := syncMountedWorkspaceBack(ctx, cfg, store, store.rdb, "repo", head)
+	saved, err := saveWorkspaceRootCheckpoint(ctx, store, "repo", head, "mounted-save")
 	if err != nil {
-		t.Fatalf("syncMountedWorkspaceBack() returned error: %v", err)
+		t.Fatalf("saveWorkspaceRootCheckpoint() returned error: %v", err)
 	}
 	if !saved {
 		t.Fatal("expected mounted workspace sync to create a new savepoint")
@@ -150,23 +217,36 @@ func TestSyncMountedWorkspaceBackSavesMountChangesIntoWorkspace(t *testing.T) {
 		t.Fatalf("HeadSavepoint = %q, want a new savepoint after mounted edits", workspaceMeta.HeadSavepoint)
 	}
 
-	data, err := os.ReadFile(filepath.Join(afsWorkspaceTreePath(cfg, "repo"), "mounted.txt"))
+	manifest, err := store.getManifest(ctx, "repo", workspaceMeta.HeadSavepoint)
 	if err != nil {
-		t.Fatalf("ReadFile(mounted.txt) returned error: %v", err)
+		t.Fatalf("getManifest(new head) returned error: %v", err)
+	}
+	entry, ok := manifest.Entries["/mounted.txt"]
+	if !ok {
+		t.Fatal("expected /mounted.txt in saved workspace manifest")
+	}
+	data, err := controlplane.ManifestEntryData(entry, func(blobID string) ([]byte, error) {
+		return store.getBlob(ctx, "repo", blobID)
+	})
+	if err != nil {
+		t.Fatalf("ManifestEntryData(/mounted.txt) returned error: %v", err)
 	}
 	if string(data) != "hello from mount\n" {
-		t.Fatalf("mounted.txt = %q, want %q", string(data), "hello from mount\n")
+		t.Fatalf("saved /mounted.txt = %q, want %q", string(data), "hello from mount\n")
+	}
+	if _, err := os.Stat(afsWorkspaceTreePath(cfg, "repo")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no local workspace tree after mounted sync, stat err = %v", err)
 	}
 }
 
-func TestSyncMountedWorkspaceBackIgnoresMountedSystemArtifacts(t *testing.T) {
+func TestSaveWorkspaceRootCheckpointIgnoresMountedSystemArtifacts(t *testing.T) {
 	t.Helper()
 
-	cfg, _, store, closeStore := importAFSWorkspaceForTest(t)
+	cfg, store, closeStore := seedWorkspaceMountBridgeFixture(t)
 	defer closeStore()
 
 	ctx := context.Background()
-	mountKey, head, err := seedWorkspaceMountKey(ctx, cfg, store, store.rdb, "repo")
+	mountKey, head, _, err := seedWorkspaceMountKey(ctx, store, "repo")
 	if err != nil {
 		t.Fatalf("seedWorkspaceMountKey() returned error: %v", err)
 	}
@@ -179,9 +259,9 @@ func TestSyncMountedWorkspaceBackIgnoresMountedSystemArtifacts(t *testing.T) {
 		t.Fatalf("Echo(/._root.txt) returned error: %v", err)
 	}
 
-	saved, err := syncMountedWorkspaceBack(ctx, cfg, store, store.rdb, "repo", head)
+	saved, err := saveWorkspaceRootCheckpoint(ctx, store, "repo", head, "artifact-only")
 	if err != nil {
-		t.Fatalf("syncMountedWorkspaceBack() returned error: %v", err)
+		t.Fatalf("saveWorkspaceRootCheckpoint() returned error: %v", err)
 	}
 	if saved {
 		t.Fatal("expected mounted system artifacts to be ignored during sync")
@@ -194,6 +274,32 @@ func TestSyncMountedWorkspaceBackIgnoresMountedSystemArtifacts(t *testing.T) {
 	if workspaceMeta.HeadSavepoint != head {
 		t.Fatalf("HeadSavepoint = %q, want %q when only ignored mount artifacts changed", workspaceMeta.HeadSavepoint, head)
 	}
+	if _, err := os.Stat(afsWorkspaceTreePath(cfg, "repo")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected no local workspace tree after artifact-only sync, stat err = %v", err)
+	}
+}
+
+func seedWorkspaceMountBridgeFixture(t *testing.T) (config, *afsStore, func()) {
+	t.Helper()
+
+	mr := miniredis.RunT(t)
+	cfg := defaultConfig()
+	cfg.UseExistingRedis = true
+	cfg.RedisAddr = mr.Addr()
+	cfg.MountBackend = mountBackendNone
+	cfg.WorkRoot = t.TempDir()
+	cfg.CurrentWorkspace = "repo"
+	saveTempConfig(t, cfg)
+
+	loadedCfg, store, closeStore, err := openAFSStore(context.Background())
+	if err != nil {
+		t.Fatalf("openAFSStore() returned error: %v", err)
+	}
+
+	sourceDir := t.TempDir()
+	writeTestFile(t, filepath.Join(sourceDir, "main.go"), "package main\n")
+	seedWorkspaceFromDirectory(t, store, "repo", "initial", sourceDir)
+	return loadedCfg, store, closeStore
 }
 
 func mustRedisClient(t *testing.T, cfg config) *redis.Client {

--- a/docs/afs-cloud-standalone-design.md
+++ b/docs/afs-cloud-standalone-design.md
@@ -1,0 +1,505 @@
+# AFS Cloud + Standalone Design
+
+Date: 2026-04-06
+
+## Goal
+
+Adopt the useful parts of the `cloud-context-engine` design for AFS:
+
+- a cloud-managed CLI
+- a hosted control plane
+- profile-based endpoint selection
+- secure local credential storage
+- human auth for interactive use and token auth for automation
+
+But keep one stronger guarantee than that repo currently assumes:
+
+- the AFS CLI must remain fully usable with no cloud account at all
+
+Standalone mode is not a degraded fallback. It is a first-class operating mode.
+
+## What We Can Reuse From `cloud-context-engine`
+
+The other repo has a clean pattern worth copying:
+
+1. The CLI separates profile configuration from secrets.
+2. The CLI supports human login for interactive use and stored API keys for automation.
+3. The server accepts more than one auth shape depending on route and deployment mode.
+4. The deployment can switch auth behavior by mode instead of forcing one global assumption.
+
+The concrete ideas worth borrowing are:
+
+- multi-profile CLI config
+- secure credential storage outside the plain config file
+- unified auth resolution for commands
+- an HTTP control plane that becomes the only path in managed mode
+- server-side auth mode gates for cloud vs self-hosted behavior
+
+## What AFS Already Has
+
+AFS already has several pieces that line up well with that model:
+
+- a Redis-backed canonical store for workspaces, checkpoints, manifests, blobs, and audit
+- a local hybrid execution model where real work happens in a local directory
+- a local HTTP control plane and UI contract
+- workspace metadata that already includes cloud-shaped fields such as `database_id`, `database_name`, `cloud_account`, and `region`
+
+That means the product model is already compatible with a hosted control plane.
+
+## Main Gaps In AFS Today
+
+AFS is still wired as a direct Redis CLI:
+
+- commands call the store/service layer directly
+- the current HTTP server is local-only and unauthenticated
+- the HTTP API is good enough for browsing, but not yet complete enough for a remote CLI write path
+- config is a single local JSON file with Redis and mount settings only
+- there is no profile system, secure credential store, or login flow
+
+The biggest architectural issue is coupling:
+
+- the CLI currently assumes it can always open Redis directly
+
+That assumption must become optional.
+
+## Proposed Operating Modes
+
+AFS should support three explicit modes.
+
+### 1. `direct`
+
+This is the default and preserves current AFS behavior.
+
+- no cloud account
+- no hosted control plane required
+- CLI talks directly to Redis
+- local Redis management remains available
+- current mount behavior remains available
+
+This mode should continue to work on a laptop with only Redis and the AFS binaries.
+
+### 2. `self-hosted`
+
+This is for a privately deployed AFS API without a public cloud account dependency.
+
+- CLI talks to an HTTP control plane
+- storage is still managed by that deployment
+- auth can be bootstrap admin key, local token auth, or localhost-only for single-user installs
+- no Redis direct access from the CLI in normal operation
+
+This gives us the same operational shape as cloud mode without requiring AFS Cloud.
+
+### 3. `cloud`
+
+This is the managed mode modeled after `cloud-context-engine`.
+
+- CLI talks only to the hosted AFS API
+- human users authenticate with session-based login
+- automation uses stored API keys or workspace-scoped tokens
+- Redis placement, quotas, and workspace policy are controlled by the service
+- the CLI must not depend on long-lived Redis credentials
+
+## Core Design Rule
+
+Keep one command language and swap only the backend transport.
+
+That means commands like these stay the same:
+
+- `afs workspace list`
+- `afs workspace create`
+- `afs workspace import`
+- `afs workspace run`
+- `afs checkpoint create`
+- `afs checkpoint restore`
+
+What changes is how those commands are fulfilled:
+
+- `direct` uses Redis/store calls
+- `self-hosted` and `cloud` use HTTP
+
+## Proposed Backend Split
+
+Introduce a transport boundary inside the CLI.
+
+### New CLI abstraction
+
+Add a backend interface that covers the workspace lifecycle instead of exposing Redis-specific store calls everywhere.
+
+Suggested shape:
+
+```go
+type Backend interface {
+    ListWorkspaces(ctx context.Context) (WorkspaceListResponse, error)
+    GetWorkspace(ctx context.Context, workspace string) (WorkspaceDetail, error)
+    CreateWorkspace(ctx context.Context, req CreateWorkspaceRequest) (WorkspaceDetail, error)
+    DeleteWorkspace(ctx context.Context, workspace string) error
+
+    ListCheckpoints(ctx context.Context, workspace string, limit int) ([]CheckpointSummary, error)
+    CreateCheckpoint(ctx context.Context, req SaveCheckpointRequest) (bool, error)
+    RestoreCheckpoint(ctx context.Context, workspace, checkpointID string) error
+
+    GetManifest(ctx context.Context, workspace, view string) (Manifest, error)
+    GetBlob(ctx context.Context, workspace, blobID string) ([]byte, error)
+    EnsureBlobs(ctx context.Context, workspace string, blobs map[string][]byte) error
+
+    GetTree(ctx context.Context, workspace, view, path string, depth int) (TreeResponse, error)
+    GetFileContent(ctx context.Context, workspace, view, path string) (FileContentResponse, error)
+    ListActivity(ctx context.Context, workspace string, limit int) (ActivityListResponse, error)
+}
+```
+
+### Implementations
+
+- `DirectBackend`
+  - wraps the current `controlplane.Service` and `Store`
+  - preserves current behavior
+
+- `HTTPBackend`
+  - talks to an AFS API server
+  - is used by both `self-hosted` and `cloud`
+
+This is the single most important codebase change because it decouples the CLI product from direct Redis access.
+
+## Control Plane API Direction
+
+The existing AFS `/v1` contract is a good base and should be preserved.
+
+The hosted API should keep the current workspace-first model, but add the missing write/sync operations needed by a remote CLI.
+
+### Keep the existing browse-oriented endpoints
+
+- `GET /v1/workspaces`
+- `GET /v1/workspaces/{workspace_id}`
+- `POST /v1/workspaces`
+- `DELETE /v1/workspaces/{workspace_id}`
+- `GET /v1/workspaces/{workspace_id}/tree`
+- `GET /v1/workspaces/{workspace_id}/files/content`
+- `GET /v1/activity`
+- `GET /v1/workspaces/{workspace_id}/activity`
+
+### Add the missing remote-workflow endpoints
+
+- `GET /v1/workspaces/{workspace_id}/checkpoints`
+- `POST /v1/workspaces/{workspace_id}/checkpoints`
+- `POST /v1/workspaces/{workspace_id}:restore`
+- `GET /v1/workspaces/{workspace_id}/manifest?view=head|checkpoint:<id>`
+- `POST /v1/workspaces/{workspace_id}/blobs:missing`
+- `PUT /v1/workspaces/{workspace_id}/blobs/{blob_id}`
+- `GET /v1/workspaces/{workspace_id}/blobs/{blob_id}`
+- `POST /v1/workspaces/{workspace_id}/sessions`
+- `DELETE /v1/workspaces/{workspace_id}/sessions/{session_id}`
+
+### Why split manifest/blob sync from file APIs
+
+The browser/editor APIs are fine for UI use.
+
+The CLI needs a higher-throughput path for:
+
+- materializing a workspace
+- uploading changed blobs
+- creating a checkpoint with optimistic concurrency
+
+Using manifest/blob endpoints lets us reuse AFS’s current saved-state model directly instead of rebuilding it around per-file REST calls.
+
+## Authentication Model
+
+AFS should copy the shape of the other repo’s auth system, but not its assumptions.
+
+### Cloud mode
+
+Support two auth styles:
+
+- session auth for human CLI use
+- API keys or workspace tokens for automation
+
+Suggested commands:
+
+- `afs auth login`
+- `afs auth logout`
+- `afs auth status`
+
+The CLI stores:
+
+- profile metadata in config
+- secrets in keychain/keyring with encrypted fallback
+
+The server accepts:
+
+- session auth for interactive management routes
+- token auth for automation and headless tools
+
+### Self-hosted mode
+
+Support one of these server-side choices:
+
+- bootstrap admin token written once on first boot
+- local JWT auth for multi-user installs
+- localhost-only no-auth mode for single-user development
+
+The important rule is:
+
+- self-hosted mode must not require an AFS Cloud account
+
+### Direct mode
+
+No account and no fake local account.
+
+Direct mode should remain:
+
+- config + Redis connection + local filesystem behavior
+
+That is simpler and better than forcing a local login story onto single-user standalone AFS.
+
+## Profile and Config Model
+
+AFS should move from one implicit config to named profiles.
+
+Suggested shape:
+
+```json
+{
+  "default_profile": "local",
+  "profiles": {
+    "local": {
+      "mode": "direct",
+      "redis_addr": "localhost:6379",
+      "redis_username": "",
+      "redis_db": 0,
+      "redis_tls": false,
+      "work_root": "~/.afs/workspaces",
+      "mount_backend": "auto",
+      "mountpoint": "~/afs",
+      "current_workspace": ""
+    },
+    "prod": {
+      "mode": "cloud",
+      "api_url": "https://api.afs.example.com",
+      "mcp_url": "https://mcp.afs.example.com",
+      "account_id": "acct_123",
+      "work_root": "~/.afs/workspaces",
+      "current_workspace": ""
+    }
+  }
+}
+```
+
+### Secret handling
+
+Do not store these in plain config:
+
+- session refresh token
+- session cookie/token material
+- API keys
+- bootstrap admin token copies
+
+Use:
+
+- OS keyring when available
+- encrypted local fallback when it is not
+
+### Migration
+
+Preserve the existing experience by migrating the current `afs.config.json` into a generated `local` profile.
+
+Compatibility rule:
+
+- if no multi-profile config exists, read the old config and treat it as `local`
+
+## CLI Surface Changes
+
+### Existing commands remain
+
+Keep all existing workspace/checkpoint commands.
+
+### Add global profile selection
+
+- `afs --profile prod workspace list`
+- `AFS_PROFILE=prod afs workspace run my-repo -- make test`
+
+### Add auth commands
+
+- `afs auth login`
+- `afs auth logout`
+- `afs auth status`
+
+### Add profile helpers
+
+- `afs profile list`
+- `afs profile use <name>`
+- `afs profile show`
+
+### Keep `afs setup` focused on standalone
+
+`afs setup` should continue to optimize for local/direct mode.
+
+For cloud mode, setup becomes:
+
+1. create or select a cloud profile
+2. set `api_url`
+3. run `afs auth login`
+
+## Workspace Session Model
+
+To make the CLI “managed by the cloud” instead of merely “able to hit an API”, add workspace sessions.
+
+Each active CLI session should register:
+
+- workspace id
+- user or token principal
+- hostname
+- local path
+- CLI version
+- started at / last heartbeat
+- current head seen by the client
+
+This enables:
+
+- active-session visibility in the UI
+- better audit trails
+- safer concurrency messaging
+- future lease/presence behavior for multi-client workspaces
+
+## Materialization and Save Flow
+
+### `workspace run` in direct mode
+
+Keep the current flow.
+
+### `workspace run` in cloud/self-hosted mode
+
+Use this flow:
+
+1. Resolve auth and backend from the active profile.
+2. Create a workspace session.
+3. Fetch the current head manifest.
+4. Download only the blobs needed to materialize the working copy.
+5. Run the command locally in `~/.afs/workspaces/<workspace>/tree`.
+6. Build a new manifest on exit.
+7. Negotiate which blobs the server is missing.
+8. Upload only missing blobs.
+9. Create a checkpoint with `expected_head`.
+10. Close the workspace session.
+
+This preserves the existing AFS hybrid model:
+
+- canonical saved state is remote
+- real execution happens in a normal local directory
+
+## `afs up` / Mounted Filesystem Strategy
+
+This is the trickiest part because the current mount path assumes direct Redis access.
+
+### Recommendation
+
+Treat mounted filesystem support as two separate implementations:
+
+#### Direct mode
+
+Keep the current Redis-backed FUSE/NFS behavior.
+
+#### Cloud/self-hosted mode
+
+Do not require direct access to managed Redis.
+
+Instead, use a local managed working copy:
+
+- materialize the workspace into the local tree
+- optionally expose the selected mountpoint as a symlink or bind-style view to that tree
+- checkpoint explicitly or via a local background watcher/daemon
+
+This avoids leaking long-lived Redis credentials to the client and keeps the “cloud mode uses HTTP, not direct Redis” rule intact.
+
+### Practical rollout
+
+Phase 1:
+
+- full support for `workspace run`, `clone`, `checkpoint`, browse APIs, and UI in cloud mode
+- keep live mounted filesystem behavior as direct-mode only
+
+Phase 2:
+
+- add a local workspace daemon for cloud/self-hosted profiles
+- let `afs up` expose a managed local working tree with background save/refresh behavior
+
+## Server Structure
+
+AFS should split “local control plane implementation” from “transport exposure”.
+
+### Suggested structure
+
+- move the current reusable workspace/control-plane logic into a package that both CLI direct mode and servers can call
+- keep the current local server command as the development/local API binary
+- add auth middleware only at the server layer
+- add an HTTP client package for the CLI remote backend
+
+The key principle is:
+
+- business logic should not know whether the caller is local or remote
+
+## Rollout Plan
+
+### Phase 1: Backend boundary
+
+- introduce `Backend` interface in the CLI
+- refactor current commands to use `DirectBackend`
+- no product change yet
+
+### Phase 2: Complete the HTTP API
+
+- add checkpoint creation/listing endpoints
+- add manifest/blob sync endpoints
+- add an HTTP backend client
+
+### Phase 3: Profiles and credentials
+
+- add multi-profile config
+- add secure credential storage
+- add `afs auth ...` commands
+- migrate legacy config to `local`
+
+### Phase 4: Hosted/self-hosted auth
+
+- add server auth middleware
+- support session auth + API keys for cloud
+- support bootstrap token and/or local JWT auth for self-hosted
+
+### Phase 5: Cloud-managed sessions
+
+- add workspace session records
+- expose them in UI/activity
+- wire optimistic concurrency and better conflict reporting through the API
+
+### Phase 6: Cloud-mode `afs up`
+
+- add local workspace daemon and optional background save/refresh
+- keep direct-mode live mount untouched
+
+## Recommended Product Positioning
+
+AFS should describe itself as:
+
+- standalone by default
+- cloud-manageable when you want it
+
+Not:
+
+- cloud-first with a local fallback
+
+That positioning matches the current codebase and keeps the design honest.
+
+## Bottom Line
+
+The best way to replicate the `cloud-context-engine` design in AFS is:
+
+- copy the profile/auth/control-plane transport pattern
+- do not copy the assumption that every serious deployment starts from a cloud account
+- make `direct` a first-class backend, not a compatibility mode
+- make `cloud` and `self-hosted` HTTP backends that sit beside it
+
+If we do that, AFS gets:
+
+- a managed cloud story
+- a self-hosted story
+- a zero-account standalone story
+
+without fragmenting the command surface or the workspace model.

--- a/examples/codex-settings-migration.md
+++ b/examples/codex-settings-migration.md
@@ -71,20 +71,19 @@ logs/
 EOF
 ```
 
-Import the existing directory into the `.codex` workspace and replace it in place with an AFS-managed copy:
+Import the existing directory into the `.codex` workspace and mount it in place:
 
 ```bash
-./afs workspace import --clone-at-source .codex ~/.codex
+./afs workspace import --mount-at-source .codex ~/.codex
 ./afs workspace use .codex
-./afs up
 ```
 
 What that does:
 
 - imports `~/.codex` into the workspace `.codex`
 - moves your original directory to `~/.codex.pre-afs`
-- materializes the imported workspace back at `~/.codex`
-- mounts the current workspace at `~/.codex`
+- mounts the imported workspace at `~/.codex`
+- keeps `.codex` selected for future `./afs up` runs
 
 Verify:
 
@@ -126,7 +125,7 @@ If you want an agent to perform this, the agent should:
 2. Recommend creating `~/.codex/.afsignore` before import.
 3. Suggest excluding `worktrees/` by default, unless the user explicitly wants local checkout state shared.
 4. Build `agent-filesystem` with `make`.
-5. On the first machine, run `./afs setup`, then `./afs workspace import --clone-at-source .codex ~/.codex`, then `./afs workspace use .codex`, then `./afs up`.
+5. On the first machine, run `./afs setup`, then `./afs workspace import --mount-at-source .codex ~/.codex`, then `./afs workspace use .codex`.
 6. On later machines, back up any existing `~/.codex`, run `./afs setup` with workspace `.codex` and mountpoint `~/.codex`, then run `./afs up`.
 7. Verify that the same Codex files appear on every machine.
 

--- a/mount/internal/client/native_helpers.go
+++ b/mount/internal/client/native_helpers.go
@@ -49,7 +49,7 @@ func (c *nativeClient) ensureRoot(ctx context.Context) error {
 	}
 
 	pipe := c.rdb.TxPipeline()
-	pipe.HSet(ctx, c.keys.inode(rootInodeID), c.inodeFields(root, false))
+	pipe.HSet(ctx, c.keys.inode(rootInodeID), c.inodeFieldsAtPath(root, "/", false))
 	pipe.HSet(ctx, c.keys.info(), map[string]interface{}{
 		"schema_version":   schemaVersion,
 		"files":            0,
@@ -280,7 +280,7 @@ func (c *nativeClient) saveInode(ctx context.Context, p string, inode *inodeData
 	if inode == nil || inode.ID == "" {
 		return errors.New("missing inode id")
 	}
-	if err := c.saveInodeDirect(ctx, inode, true); err != nil {
+	if err := c.saveInodeAtPath(ctx, p, inode, true); err != nil {
 		return err
 	}
 	c.cachePath(p, inode)
@@ -291,11 +291,18 @@ func (c *nativeClient) saveInodeMeta(ctx context.Context, p string, inode *inode
 	if inode == nil || inode.ID == "" {
 		return errors.New("missing inode id")
 	}
-	if err := c.saveInodeDirect(ctx, inode, false); err != nil {
+	if err := c.saveInodeAtPath(ctx, p, inode, false); err != nil {
 		return err
 	}
 	c.cachePath(p, inode)
 	return nil
+}
+
+func (c *nativeClient) saveInodeAtPath(ctx context.Context, p string, inode *inodeData, includeContent bool) error {
+	if inode == nil || inode.ID == "" {
+		return errors.New("missing inode id")
+	}
+	return c.rdb.HSet(ctx, c.keys.inode(inode.ID), c.inodeFieldsAtPath(inode, p, includeContent)).Err()
 }
 
 func (c *nativeClient) saveInodeDirect(ctx context.Context, inode *inodeData, includeContent bool) error {
@@ -345,7 +352,7 @@ func (c *nativeClient) createInodeUnderParent(ctx context.Context, childPath str
 	now := nowMs()
 
 	pipe := c.rdb.Pipeline()
-	pipe.HSet(ctx, c.keys.inode(id), c.inodeFields(inode, inode.Type == "file"))
+	pipe.HSet(ctx, c.keys.inode(id), c.inodeFieldsAtPath(inode, childPath, inode.Type == "file"))
 	pipe.HSet(ctx, c.keys.dirents(parent.ID), name, id)
 	c.queueTouchTimes(pipe, parent.ID, now)
 	c.queueCreateInfo(pipe, inode)
@@ -422,7 +429,7 @@ func (c *nativeClient) createFileIfMissing(ctx context.Context, p string, conten
 			Content: content,
 		}
 		if _, err := tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
-			pipe.HSet(ctx, c.keys.inode(inode.ID), c.inodeFields(inode, true))
+			pipe.HSet(ctx, c.keys.inode(inode.ID), c.inodeFieldsAtPath(inode, p, true))
 			pipe.HSet(ctx, direntsKey, name, inode.ID)
 			c.queueTouchTimes(pipe, parentInode.ID, now)
 			c.queueCreateInfo(pipe, inode)
@@ -524,9 +531,11 @@ func (c *nativeClient) renamePath(ctx context.Context, resolvedSrc string, srcIn
 				pipe.HDel(ctx, c.keys.dirents(oldParentID), oldName)
 				pipe.HSet(ctx, c.keys.dirents(newParent.ID), newName, nextSrc.ID)
 				pipe.HSet(ctx, c.keys.inode(nextSrc.ID), map[string]interface{}{
-					"parent":   nextSrc.Parent,
-					"name":     nextSrc.Name,
-					"ctime_ms": nextSrc.CtimeMs,
+					"parent":         nextSrc.Parent,
+					"name":           nextSrc.Name,
+					"ctime_ms":       nextSrc.CtimeMs,
+					"path":           dst,
+					"path_ancestors": indexedPathAncestors(dst),
 				})
 				c.queueTouchTimes(pipe, oldParentID, nextSrc.CtimeMs)
 				if newParent.ID != oldParentID {
@@ -556,6 +565,9 @@ func (c *nativeClient) renamePath(ctx context.Context, resolvedSrc string, srcIn
 			c.invalidateInode(parentOf(dst))
 			c.invalidatePrefix(resolvedSrc)
 			c.invalidatePrefix(dst)
+			if err := c.refreshIndexedSubtree(ctx, dst, srcInode); err != nil {
+				return err
+			}
 			return nil
 		case errors.Is(err, errNeedDirWatch):
 			watchDstDirID = nextDstDirID
@@ -656,6 +668,53 @@ func (c *nativeClient) inodeFields(inode *inodeData, includeContent bool) map[st
 		fields["content"] = inode.Content
 	}
 	return fields
+}
+
+func (c *nativeClient) inodeFieldsAtPath(inode *inodeData, p string, includeContent bool) map[string]interface{} {
+	fields := c.inodeFields(inode, includeContent)
+	fields["path"] = p
+	fields["path_ancestors"] = indexedPathAncestors(p)
+	return fields
+}
+
+func (c *nativeClient) refreshIndexedSubtree(ctx context.Context, rootPath string, inode *inodeData) error {
+	if inode == nil || inode.ID == "" {
+		return nil
+	}
+	pipe := c.rdb.Pipeline()
+	if err := c.queueRefreshIndexedSubtree(ctx, pipe, rootPath, inode); err != nil {
+		return err
+	}
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+func (c *nativeClient) queueRefreshIndexedSubtree(ctx context.Context, pipe redis.Pipeliner, currentPath string, inode *inodeData) error {
+	pipe.HSet(ctx, c.keys.inode(inode.ID), map[string]interface{}{
+		"path":           currentPath,
+		"path_ancestors": indexedPathAncestors(currentPath),
+	})
+	if inode.Type != "dir" {
+		return nil
+	}
+
+	entries, err := c.loadDirEntries(ctx, inode.ID)
+	if err != nil {
+		return err
+	}
+	for name, childID := range entries {
+		child, err := c.loadInodeByID(ctx, childID)
+		if err != nil {
+			return err
+		}
+		if child == nil {
+			continue
+		}
+		if err := c.queueRefreshIndexedSubtree(ctx, pipe, joinPath(currentPath, name), child); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (c *nativeClient) queueCreateInfo(pipe redis.Pipeliner, inode *inodeData) {
@@ -772,6 +831,28 @@ func toInt(v interface{}) int64 {
 
 func nowMs() int64 {
 	return time.Now().UnixMilli()
+}
+
+func indexedPathAncestors(path string) string {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" || trimmed == "/" {
+		return "/"
+	}
+	trimmed = strings.TrimSuffix(trimmed, "/")
+	parts := strings.Split(strings.TrimPrefix(trimmed, "/"), "/")
+	ancestors := make([]string, 0, len(parts)+1)
+	current := ""
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		current += "/" + part
+		ancestors = append(ancestors, current)
+	}
+	if len(ancestors) == 0 {
+		return "/"
+	}
+	return strings.Join(ancestors, ",")
 }
 
 func splitComponents(p string) []string {

--- a/mount/internal/client/native_test.go
+++ b/mount/internal/client/native_test.go
@@ -182,6 +182,12 @@ func TestCanonicalInodeStorageFormat(t *testing.T) {
 	if vals["name"] != "hello.txt" {
 		t.Fatalf("expected name=hello.txt, got %q", vals["name"])
 	}
+	if vals["path"] != "/hello.txt" {
+		t.Fatalf("expected path=/hello.txt, got %q", vals["path"])
+	}
+	if vals["path_ancestors"] != "/hello.txt" {
+		t.Fatalf("expected path_ancestors=/hello.txt, got %q", vals["path_ancestors"])
+	}
 
 	rootDirentsKey := "afs:{keytest}:dirents:" + rootInodeID
 	childID, err := rdb.HGet(ctx, rootDirentsKey, "hello.txt").Result()
@@ -429,6 +435,43 @@ func TestRenameReplacesEmptyDirectory(t *testing.T) {
 	}
 	if string(data) != "payload" {
 		t.Fatalf("unexpected nested content after dir replace: %q", string(data))
+	}
+}
+
+func TestRenameUpdatesIndexedPathsForDirectorySubtree(t *testing.T) {
+	t.Parallel()
+	rdb, ctx := setupTestRedis(t)
+	c := New(rdb, "rename-indexed-paths")
+
+	if err := c.Mkdir(ctx, "/src/sub"); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	if err := c.Echo(ctx, "/src/sub/file.txt", []byte("payload")); err != nil {
+		t.Fatalf("echo nested file: %v", err)
+	}
+
+	before, err := c.Stat(ctx, "/src/sub/file.txt")
+	if err != nil {
+		t.Fatalf("stat before rename: %v", err)
+	}
+	if before == nil || before.Inode == 0 {
+		t.Fatalf("expected file inode before rename, got %+v", before)
+	}
+
+	if err := c.Rename(ctx, "/src", "/dst", 0); err != nil {
+		t.Fatalf("rename src to dst: %v", err)
+	}
+
+	inodeKey := "afs:{rename-indexed-paths}:inode:" + strconv.FormatUint(before.Inode, 10)
+	vals, err := rdb.HGetAll(ctx, inodeKey).Result()
+	if err != nil {
+		t.Fatalf("hgetall renamed inode: %v", err)
+	}
+	if vals["path"] != "/dst/sub/file.txt" {
+		t.Fatalf("path = %q, want %q", vals["path"], "/dst/sub/file.txt")
+	}
+	if vals["path_ancestors"] != "/dst,/dst/sub,/dst/sub/file.txt" {
+		t.Fatalf("path_ancestors = %q, want %q", vals["path_ancestors"], "/dst,/dst/sub,/dst/sub/file.txt")
 	}
 }
 

--- a/skills/codex-settings-sync/SKILL.md
+++ b/skills/codex-settings-sync/SKILL.md
@@ -22,8 +22,8 @@ Open the bundled starter ignore file at [assets/.afsignore](assets/.afsignore) a
 2. Ensure `agent-filesystem` is built with `make`.
 3. Configure `afs` to point at the shared Redis instance.
 4. Create or update `~/.codex/.afsignore` before migration.
-5. On the source machine, run `./afs workspace import --clone-at-source .codex ~/.codex`, then `./afs workspace use .codex`, then `./afs up`.
-6. Explain that the original directory becomes `~/.codex.pre-afs`, the imported working copy returns at `~/.codex`, and the workspace name is `.codex`.
+5. On the source machine, run `./afs workspace import --mount-at-source .codex ~/.codex`, then `./afs workspace use .codex`.
+6. Explain that the original directory becomes `~/.codex.pre-afs`, the imported workspace is mounted at `~/.codex`, and the workspace name is `.codex`.
 7. On each additional machine, move aside any existing `~/.codex`, configure the current workspace as `.codex`, set `mountpoint` to that machine's `~/.codex`, then run `./afs up`.
 8. Verify with `./afs status` and `ls -la ~/.codex`.
 

--- a/ui/src/foundation/api/afs.test.ts
+++ b/ui/src/foundation/api/afs.test.ts
@@ -46,4 +46,19 @@ describe("afsApi", () => {
     expect(savedWorkspace?.draftState).toBe("clean");
     expect(savedWorkspace?.savepoints[0]?.name).toBe("after-update");
   });
+
+  test("updates workspace metadata", async () => {
+    const workspace = await afsApi.updateWorkspace({
+      workspaceId: "payments-portal",
+      description: "Updated description",
+      cloudAccount: "Redis Cloud / Updated",
+      databaseName: "payments-portal-prod-us-east-1",
+      region: "us-east-2",
+    });
+
+    expect(workspace?.description).toBe("Updated description");
+    expect(workspace?.cloudAccount).toBe("Redis Cloud / Updated");
+    expect(workspace?.databaseName).toBe("payments-portal-prod-us-east-1");
+    expect(workspace?.region).toBe("us-east-2");
+  });
 });

--- a/ui/src/foundation/api/afs.ts
+++ b/ui/src/foundation/api/afs.ts
@@ -19,6 +19,7 @@ import type {
   AFSWorkspaceSummary,
   AFSWorkspaceView,
   RestoreSavepointInput,
+  UpdateWorkspaceInput,
   UpdateWorkspaceFileInput,
 } from "../types/afs";
 
@@ -32,6 +33,7 @@ type AFSClient = {
   getWorkspace: (workspaceId: string) => Promise<AFSWorkspaceDetail | null>;
   createWorkspace: (input: CreateWorkspaceInput) => Promise<AFSWorkspaceDetail>;
   deleteWorkspace: (workspaceId: string) => Promise<void>;
+  updateWorkspace: (input: UpdateWorkspaceInput) => Promise<AFSWorkspaceDetail | null>;
   updateWorkspaceFile: (input: UpdateWorkspaceFileInput) => Promise<AFSWorkspaceDetail | null>;
   createSavepoint: (input: CreateSavepointInput) => Promise<AFSWorkspaceDetail | null>;
   restoreSavepoint: (input: RestoreSavepointInput) => Promise<AFSWorkspaceDetail | null>;
@@ -44,6 +46,7 @@ type AFSClient = {
 type HTTPWorkspaceSummary = {
   id: string;
   name: string;
+  cloud_account: string;
   database_id: string;
   database_name: string;
   redis_key: string;
@@ -307,6 +310,7 @@ function workspaceToSummary(workspace: AFSWorkspace): AFSWorkspaceSummary {
   return {
     id: normalized.id,
     name: normalized.name,
+    cloudAccount: normalized.cloudAccount,
     databaseId: normalized.databaseId,
     databaseName: normalized.databaseName,
     redisKey: normalized.redisKey,
@@ -593,6 +597,32 @@ This workspace was created from the AFS Web UI.
     });
   },
 
+  async updateWorkspace(input: UpdateWorkspaceInput) {
+    await wait();
+    const state = updateState((draft) => {
+      const workspace = requireWorkspace(draft, input.workspaceId);
+      workspace.description = input.description.trim();
+      workspace.cloudAccount = input.cloudAccount.trim();
+      workspace.databaseName = input.databaseName.trim();
+      workspace.region = input.region.trim();
+      workspace.tags = [workspace.region, sourceLabel(workspace.source)].filter(Boolean);
+      touchWorkspace(workspace);
+      workspace.activity.unshift(
+        createActivity(
+          `Updated ${workspace.name}`,
+          "Workspace details were updated from the Web UI.",
+          "webui",
+          "workspace.updated",
+          "workspace",
+          workspace.id,
+          workspace.name,
+        ),
+      );
+    });
+
+    return normalizeWorkspace(requireWorkspace(state, input.workspaceId));
+  },
+
   async updateWorkspaceFile(input: UpdateWorkspaceFileInput) {
     await wait();
     const state = updateState((draft) => {
@@ -823,6 +853,7 @@ function mapWorkspaceSummary(input: HTTPWorkspaceSummary): AFSWorkspaceSummary {
   return {
     id: input.id,
     name: input.name,
+    cloudAccount: input.cloud_account,
     databaseId: input.database_id,
     databaseName: input.database_name,
     redisKey: input.redis_key,
@@ -945,6 +976,20 @@ const httpAFSClient: AFSClient = {
     await requestJSON<void>(`/workspaces/${workspaceId}`, {
       method: "DELETE",
     });
+  },
+
+  async updateWorkspace(input: UpdateWorkspaceInput) {
+    return mapWorkspaceDetail(
+      await requestJSON<HTTPWorkspaceDetail>(`/workspaces/${input.workspaceId}`, {
+        method: "PUT",
+        body: JSON.stringify({
+          description: input.description,
+          database_name: input.databaseName,
+          cloud_account: input.cloudAccount,
+          region: input.region,
+        }),
+      }),
+    );
   },
 
   async updateWorkspaceFile() {

--- a/ui/src/foundation/hooks/use-afs.ts
+++ b/ui/src/foundation/hooks/use-afs.ts
@@ -11,6 +11,7 @@ import type {
   GetWorkspaceFileContentInput,
   GetWorkspaceTreeInput,
   RestoreSavepointInput,
+  UpdateWorkspaceInput,
   UpdateWorkspaceFileInput,
 } from "../types/afs";
 
@@ -34,11 +35,12 @@ export function useWorkspaceSummaries() {
   );
 }
 
-export function useWorkspace(workspaceId: string) {
+export function useWorkspace(workspaceId: string, enabled = true) {
   return useQuery(
     queryOptions({
       queryKey: afsKeys.workspace(workspaceId),
       queryFn: () => afsApi.getWorkspace(workspaceId),
+      enabled,
     }),
   );
 }
@@ -121,6 +123,17 @@ export function useDeleteWorkspaceMutation() {
     mutationFn: (workspaceId: string) => afsApi.deleteWorkspace(workspaceId),
     onSuccess: async () => {
       await invalidate();
+    },
+  });
+}
+
+export function useUpdateWorkspaceMutation() {
+  const invalidate = useWorkspaceInvalidation();
+
+  return useMutation({
+    mutationFn: (input: UpdateWorkspaceInput) => afsApi.updateWorkspace(input),
+    onSuccess: async (_, variables) => {
+      await invalidate(variables.workspaceId);
     },
   });
 }

--- a/ui/src/foundation/tables/activity-table.tsx
+++ b/ui/src/foundation/tables/activity-table.tsx
@@ -1,0 +1,202 @@
+import { TableHeading, Typography } from "@redislabsdev/redis-ui-components";
+import { Table } from "@redislabsdev/redis-ui-table";
+import type { ColumnDef, SortingState } from "@redislabsdev/redis-ui-table";
+import { useMemo, useState } from "react";
+import type { AFSActivityEvent } from "../types/afs";
+import * as S from "./workspace-table.styles";
+
+type ActivitySortField = "createdAt" | "workspaceName" | "title" | "scope" | "actor";
+
+type Props = {
+  rows: AFSActivityEvent[];
+  loading?: boolean;
+  error?: boolean;
+  errorMessage?: string;
+  onOpenActivity: (event: AFSActivityEvent) => void;
+};
+
+function compareValues(
+  left: string | number,
+  right: string | number,
+  direction: "asc" | "desc",
+) {
+  const result =
+    typeof left === "number" && typeof right === "number"
+      ? left - right
+      : String(left).localeCompare(String(right));
+
+  return direction === "asc" ? result : result * -1;
+}
+
+export function ActivityTable({
+  rows,
+  loading = false,
+  error = false,
+  errorMessage = "Unable to load activity. Please retry.",
+  onOpenActivity,
+}: Props) {
+  const [search, setSearch] = useState("");
+  const [sortBy, setSortBy] = useState<ActivitySortField>("createdAt");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc");
+
+  const filteredRows = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    const baseRows =
+      query === ""
+        ? rows
+        : rows.filter((row) =>
+            [
+              row.workspaceName ?? "",
+              row.workspaceId ?? "",
+              row.title,
+              row.detail,
+              row.actor,
+              row.scope,
+              row.kind,
+            ].some((value) => value.toLowerCase().includes(query)),
+          );
+
+    return [...baseRows].sort((left, right) => {
+      const leftValue =
+        sortBy === "workspaceName" ? left.workspaceName ?? left.workspaceId ?? "" : left[sortBy];
+      const rightValue =
+        sortBy === "workspaceName"
+          ? right.workspaceName ?? right.workspaceId ?? ""
+          : right[sortBy];
+
+      return compareValues(leftValue, rightValue, sortDirection);
+    });
+  }, [rows, search, sortBy, sortDirection]);
+
+  const sorting = useMemo<SortingState>(
+    () => [{ id: sortBy, desc: sortDirection === "desc" }],
+    [sortBy, sortDirection],
+  );
+
+  const columns = useMemo(
+    () =>
+      [
+        {
+          accessorKey: "createdAt",
+          header: "When",
+          size: 80,
+          enableSorting: true,
+          cell: ({ row }) => new Date(row.original.createdAt).toLocaleString(),
+        },
+        {
+          accessorKey: "workspaceName",
+          header: "Workspace",
+          size: 90,
+          enableSorting: true,
+          cell: ({ row }) => (
+            <S.Stack>
+              <Typography.Body component="strong">
+                {row.original.workspaceName ?? row.original.workspaceId ?? "Global"}
+              </Typography.Body>
+              <Typography.Body color="secondary" component="span">
+                {row.original.scope}
+              </Typography.Body>
+            </S.Stack>
+          ),
+        },
+        {
+          accessorKey: "title",
+          header: "Activity",
+          size: 140,
+          enableSorting: true,
+          cell: ({ row }) => (
+            <S.Stack>
+              <Typography.Body component="strong">{row.original.title}</Typography.Body>
+              <Typography.Body color="secondary" component="span">
+                {row.original.detail}
+              </Typography.Body>
+            </S.Stack>
+          ),
+        },
+        {
+          accessorKey: "actor",
+          header: "Actor",
+          size: 70,
+          enableSorting: true,
+        },
+        {
+          accessorKey: "scope",
+          header: "Type",
+          size: 60,
+          enableSorting: true,
+          cell: ({ row }) => (
+            <S.Stack>
+              <Typography.Body component="span">{row.original.scope}</Typography.Body>
+              <Typography.Body color="secondary" component="span">
+                {row.original.kind}
+              </Typography.Body>
+            </S.Stack>
+          ),
+        },
+        {
+          id: "actions",
+          header: "",
+          size: 50,
+          enableSorting: false,
+          cell: ({ row }) => (
+            <S.TextActionButton
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                onOpenActivity(row.original);
+              }}
+            >
+              Open
+            </S.TextActionButton>
+          ),
+        },
+      ] as ColumnDef<AFSActivityEvent>[],
+    [onOpenActivity],
+  );
+
+  return (
+    <S.TableCard>
+      <S.HeadingWrap>
+        <TableHeading>
+          <TableHeading.Title>Activity across all workspaces</TableHeading.Title>
+        </TableHeading>
+        <S.SearchInput
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search workspace, activity, actor, scope, or detail"
+        />
+      </S.HeadingWrap>
+
+      {loading ? <S.EmptyState>Loading activity...</S.EmptyState> : null}
+      {error ? <S.EmptyState role="alert">{errorMessage}</S.EmptyState> : null}
+      {!loading && !error && filteredRows.length === 0 ? (
+        <S.EmptyState>No activity matches the current filter.</S.EmptyState>
+      ) : null}
+
+      {!loading && !error && filteredRows.length > 0 ? (
+        <S.TableViewport>
+          <Table
+            columns={columns}
+            data={filteredRows}
+            sorting={sorting}
+            manualSorting
+            onSortingChange={(nextState) => {
+              if (nextState.length === 0) {
+                setSortBy("createdAt");
+                setSortDirection("desc");
+                return;
+              }
+
+              const next = nextState[0];
+              setSortBy(next.id as ActivitySortField);
+              setSortDirection(next.desc ? "desc" : "asc");
+            }}
+            enableSorting
+            stripedRows
+            onRowClick={(rowData) => onOpenActivity(rowData)}
+          />
+        </S.TableViewport>
+      ) : null}
+    </S.TableCard>
+  );
+}

--- a/ui/src/foundation/tables/workspace-table.styles.ts
+++ b/ui/src/foundation/tables/workspace-table.styles.ts
@@ -28,6 +28,46 @@ export const TableViewport = styled.div`
   }
 `;
 
+export const RegistryTableViewport = styled(TableViewport)`
+  /* Remove vertical separator between Health | Workspace (columns 1|2). */
+  thead tr > *:nth-child(1),
+  [role="row"] > [role="columnheader"]:nth-child(1) {
+    border-right: none !important;
+    box-shadow: none !important;
+  }
+
+  thead tr > *:nth-child(2),
+  [role="row"] > [role="columnheader"]:nth-child(2) {
+    border-left: none !important;
+  }
+
+  /* Remove vertical separator between Updated | More actions (columns 7|8). */
+  thead tr > *:nth-child(7),
+  [role="row"] > [role="columnheader"]:nth-child(7) {
+    border-right: none !important;
+    box-shadow: none !important;
+  }
+
+  thead tr > *:nth-child(8),
+  [role="row"] > [role="columnheader"]:nth-child(8) {
+    border-left: none !important;
+  }
+
+  thead tr > *:nth-child(1)::before,
+  thead tr > *:nth-child(1)::after,
+  thead tr > *:nth-child(7)::before,
+  thead tr > *:nth-child(7)::after,
+  [role="row"] > [role="columnheader"]:nth-child(1)::before,
+  [role="row"] > [role="columnheader"]:nth-child(1)::after,
+  [role="row"] > [role="columnheader"]:nth-child(7)::before,
+  [role="row"] > [role="columnheader"]:nth-child(7)::after {
+    border: 0 !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    content: none !important;
+  }
+`;
+
 export const EmptyState = styled.div`
   padding: 40px;
   text-align: center;
@@ -55,7 +95,104 @@ export const Stack = styled.div`
   gap: 4px;
 `;
 
+export const StatusCaption = styled.span`
+  color: ${({ theme }) => theme.semantic.color.text.neutral600};
+  font-size: 12px;
+`;
+
+export const ActionRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+`;
+
+export const CountCell = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+`;
+
+export const MetaBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: ${({ theme }) => theme.semantic.color.background.neutral100};
+  color: ${({ theme }) => theme.semantic.color.text.neutral700};
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.4;
+`;
+
+export const HealthDot = styled.span<{ $active: boolean; $syncing?: boolean }>`
+  width: 8px;
+  height: 8px;
+  min-width: 8px;
+  border-radius: 999px;
+  display: inline-block;
+  background-color: ${({ $active, $syncing, theme }) =>
+    !$active
+      ? theme.semantic.color.background.danger500
+      : $syncing
+        ? theme.semantic.color.background.warning500
+        : theme.semantic.color.background.success500};
+`;
+
+export const HealthCell = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  min-width: 16px;
+  overflow: visible;
+`;
+
+const actionButtonBase = styled.button`
+  border: none;
+  background: transparent;
+  padding: 0;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: opacity 160ms ease;
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.45;
+  }
+`;
+
+export const TextActionButton = styled(actionButtonBase)`
+  color: ${({ theme }) => theme.semantic.color.text.primary600};
+`;
+
+export const DangerActionButton = styled(actionButtonBase)`
+  color: #c2364a;
+`;
+
+export const MoreActionsTrigger = styled.button`
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    background: ${({ theme }) => theme.semantic.color.background.neutral100};
+  }
+`;
+
 export const SearchInput = styled(TableHeading.SearchInput)`
+  && {
+    align-self: flex-start;
+  }
+
   width: 320px;
   border-radius: 8px !important;
   border: 1px solid ${({ theme }) => theme.semantic.color.border.neutral200} !important;
@@ -78,4 +215,8 @@ export const HeadingWrap = styled.div`
     flex-direction: column;
     align-items: stretch;
   }
+`;
+
+export const SearchOnlyHeadingWrap = styled(HeadingWrap)`
+  justify-content: flex-start;
 `;

--- a/ui/src/foundation/tables/workspace-table.tsx
+++ b/ui/src/foundation/tables/workspace-table.tsx
@@ -1,22 +1,18 @@
-import { Button, TableHeading, Typography } from "@redislabsdev/redis-ui-components";
+import { Menu, Typography } from "@redislabsdev/redis-ui-components";
+import { MoreactionsIcon } from "@redislabsdev/redis-ui-icons/monochrome";
 import { Table } from "@redislabsdev/redis-ui-table";
 import type { ColumnDef, SortingState } from "@redislabsdev/redis-ui-table";
 import { useMemo, useState } from "react";
 import { formatBytes } from "../api/afs";
-import type {
-  AFSDraftState,
-  AFSWorkspaceStatus,
-  AFSWorkspaceSummary,
-} from "../types/afs";
-import { ToneChip } from "../../components/afs-kit";
+import type { AFSWorkspaceSummary } from "../types/afs";
 import * as S from "./workspace-table.styles";
 
 type WorkspaceSortField =
   | "name"
+  | "cloudAccount"
   | "databaseName"
   | "fileCount"
   | "totalBytes"
-  | "draftState"
   | "checkpointCount"
   | "updatedAt";
 
@@ -25,7 +21,11 @@ type Props = {
   loading?: boolean;
   error?: boolean;
   errorMessage?: string;
+  onPreviewWorkspace: (workspaceId: string) => void;
   onOpenWorkspace: (workspaceId: string) => void;
+  onEditWorkspace: (workspaceId: string) => void;
+  onDeleteWorkspace: (workspaceId: string) => void;
+  deletingWorkspaceId?: string | null;
 };
 
 function compareValues(
@@ -46,7 +46,11 @@ export function WorkspaceTable({
   loading = false,
   error = false,
   errorMessage = "Unable to load workspaces. Please retry.",
+  onPreviewWorkspace,
   onOpenWorkspace,
+  onEditWorkspace,
+  onDeleteWorkspace,
+  deletingWorkspaceId = null,
 }: Props) {
   const [search, setSearch] = useState("");
   const [sortBy, setSortBy] = useState<WorkspaceSortField>("updatedAt");
@@ -58,7 +62,7 @@ export function WorkspaceTable({
       query === ""
         ? rows
         : rows.filter((row) =>
-            [row.name, row.databaseName, row.redisKey, row.region].some((value) =>
+            [row.name, row.databaseName, row.redisKey, row.region, row.cloudAccount].some((value) =>
               value.toLowerCase().includes(query),
             ),
           );
@@ -74,27 +78,42 @@ export function WorkspaceTable({
     () => [{ id: sortBy, desc: sortDirection === "desc" }],
     [sortBy, sortDirection],
   );
+  const isFiltering = search.trim() !== "";
 
   const columns = useMemo(
     () =>
       [
         {
+          id: "health",
           accessorKey: "status",
-          header: "Status",
-          size: 24,
-          cell: ({ row }) => (
-            <ToneChip $tone={row.original.status}>{statusLabel(row.original.status)}</ToneChip>
-          ),
+          header: "",
+          size: 20,
+          minSize: 20,
+          maxSize: 20,
           enableSorting: false,
+          cell: ({ row }) => (
+            <S.HealthCell>
+              <S.HealthDot
+                $active={row.original.status !== "attention"}
+                $syncing={row.original.status === "syncing"}
+                aria-label={`health-${row.original.status}`}
+              />
+            </S.HealthCell>
+          ),
         },
         {
           accessorKey: "name",
-          header: "Workspace",
+          header: "Workspace name",
           size: 110,
           enableSorting: true,
           cell: ({ row }) => (
             <S.Stack>
-              <S.WorkspaceNameButton onClick={() => onOpenWorkspace(row.original.id)}>
+              <S.WorkspaceNameButton
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onPreviewWorkspace(row.original.id);
+                }}
+              >
                 {row.original.name}
               </S.WorkspaceNameButton>
               <Typography.Body color="secondary" component="span">
@@ -105,30 +124,27 @@ export function WorkspaceTable({
         },
         {
           accessorKey: "databaseName",
-          header: "Database",
-          size: 90,
+          header: "Database hosting",
+          size: 110,
           enableSorting: true,
           cell: ({ row }) => (
             <S.Stack>
               <Typography.Body component="strong">{row.original.databaseName}</Typography.Body>
               <Typography.Body color="secondary" component="span">
-                {row.original.region}
+                {row.original.cloudAccount} · {row.original.region}
               </Typography.Body>
             </S.Stack>
           ),
         },
         {
           accessorKey: "fileCount",
-          header: "Content",
+          header: "Files/Folder",
           size: 70,
           enableSorting: true,
           cell: ({ row }) => (
-            <S.Stack>
-              <Typography.Body component="span">{row.original.folderCount} folders</Typography.Body>
-              <Typography.Body color="secondary" component="span">
-                {row.original.fileCount} files
-              </Typography.Body>
-            </S.Stack>
+            <Typography.Body component="span">
+              {row.original.fileCount}/{row.original.folderCount}
+            </Typography.Body>
           ),
         },
         {
@@ -139,40 +155,15 @@ export function WorkspaceTable({
           cell: ({ row }) => formatBytes(row.original.totalBytes),
         },
         {
-          accessorKey: "draftState",
-          header: "Draft",
-          size: 60,
-          enableSorting: true,
-          cell: ({ row }) => (
-            <S.Stack>
-              <ToneChip $tone={row.original.draftState}>
-                {draftStateLabel(row.original.draftState)}
-              </ToneChip>
-              <Typography.Body color="secondary" component="span">
-                Working copy state
-              </Typography.Body>
-            </S.Stack>
-          ),
-        },
-        {
           accessorKey: "checkpointCount",
           header: "Checkpoints",
           size: 65,
           enableSorting: true,
-          cell: ({ row }) => (
-            <S.Stack>
-              <Typography.Body component="span">
-                {row.original.checkpointCount} checkpoints
-              </Typography.Body>
-              <Typography.Body color="secondary" component="span">
-                Last: {new Date(row.original.lastCheckpointAt).toLocaleDateString()}
-              </Typography.Body>
-            </S.Stack>
-          ),
+          cell: ({ row }) => row.original.checkpointCount,
         },
         {
           accessorKey: "updatedAt",
-          header: "Updated",
+          header: "Last updated",
           size: 65,
           enableSorting: true,
           cell: ({ row }) => new Date(row.original.updatedAt).toLocaleString(),
@@ -180,43 +171,70 @@ export function WorkspaceTable({
         {
           id: "actions",
           header: "",
-          size: 42,
+          size: 10,
+          maxSize: 10,
           enableSorting: false,
           cell: ({ row }) => (
-            <Button
-              size="medium"
-              variant="secondary-fill"
-              onClick={() => onOpenWorkspace(row.original.id)}
-            >
-              Open
-            </Button>
+            <Menu>
+              <Menu.Trigger withButton={false}>
+                <S.MoreActionsTrigger
+                  aria-label={`More actions for ${row.original.name}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                  }}
+                >
+                  <MoreactionsIcon size="S" />
+                </S.MoreActionsTrigger>
+              </Menu.Trigger>
+              <Menu.Content align="end">
+                <Menu.Content.Item
+                  text="Open workspace"
+                  onClick={() => onOpenWorkspace(row.original.id)}
+                />
+                <Menu.Content.Item
+                  text="Edit workspace"
+                  onClick={() => onEditWorkspace(row.original.id)}
+                />
+                <Menu.Content.Item
+                  text={deletingWorkspaceId === row.original.id ? "Deleting..." : "Delete workspace"}
+                  onClick={() => {
+                    if (deletingWorkspaceId === row.original.id) {
+                      return;
+                    }
+                    onDeleteWorkspace(row.original.id);
+                  }}
+                />
+              </Menu.Content>
+            </Menu>
           ),
         },
       ] as ColumnDef<AFSWorkspaceSummary>[],
-    [onOpenWorkspace],
+    [deletingWorkspaceId, onDeleteWorkspace, onEditWorkspace, onOpenWorkspace, onPreviewWorkspace],
   );
 
   return (
     <S.TableCard>
-      <S.HeadingWrap>
-        <TableHeading>
-          <TableHeading.Title>Workspace registry</TableHeading.Title>
-        </TableHeading>
+      <S.SearchOnlyHeadingWrap>
         <S.SearchInput
           value={search}
           onChange={(event) => setSearch(event.target.value)}
-          placeholder="Search workspace, database, key, or region"
+          placeholder="Search workspace, database, ..."
         />
-      </S.HeadingWrap>
+        
+      </S.SearchOnlyHeadingWrap>
 
       {loading ? <S.EmptyState>Loading workspaces...</S.EmptyState> : null}
       {error ? <S.EmptyState role="alert">{errorMessage}</S.EmptyState> : null}
       {!loading && !error && filteredRows.length === 0 ? (
-        <S.EmptyState>No workspaces match the current filter.</S.EmptyState>
+        <S.EmptyState>
+          {isFiltering
+            ? "No workspaces match the current filter."
+            : "No workspaces yet. Use Add workspace to create one."}
+        </S.EmptyState>
       ) : null}
 
       {!loading && !error && filteredRows.length > 0 ? (
-        <S.TableViewport>
+        <S.RegistryTableViewport>
           <Table
             columns={columns}
             data={filteredRows}
@@ -236,20 +254,10 @@ export function WorkspaceTable({
             }}
             enableSorting
             stripedRows
-            onRowClick={(rowData) => onOpenWorkspace(rowData.id)}
+            onRowClick={(rowData) => onPreviewWorkspace(rowData.id)}
           />
-        </S.TableViewport>
+        </S.RegistryTableViewport>
       ) : null}
     </S.TableCard>
   );
-}
-
-function statusLabel(status: AFSWorkspaceStatus) {
-  if (status === "healthy") return "Healthy";
-  if (status === "syncing") return "Syncing";
-  return "Attention";
-}
-
-function draftStateLabel(state: AFSDraftState) {
-  return state === "dirty" ? "Draft dirty" : "Draft clean";
 }

--- a/ui/src/foundation/types/afs.ts
+++ b/ui/src/foundation/types/afs.ts
@@ -109,6 +109,7 @@ export type AFSWorkspace = {
 export type AFSWorkspaceSummary = {
   id: string;
   name: string;
+  cloudAccount: string;
   databaseId: string;
   databaseName: string;
   redisKey: string;
@@ -145,6 +146,14 @@ export type CreateWorkspaceInput = {
   databaseName: string;
   region: string;
   source: AFSWorkspaceSource;
+};
+
+export type UpdateWorkspaceInput = {
+  workspaceId: string;
+  description: string;
+  cloudAccount: string;
+  databaseName: string;
+  region: string;
 };
 
 export type UpdateWorkspaceFileInput = {

--- a/ui/src/layout/navigation-items.ts
+++ b/ui/src/layout/navigation-items.ts
@@ -29,25 +29,9 @@ export type NavigationTitleParts = {
   page: string;
 };
 
-const workspacePanelChildren: ReadonlyArray<NavigationRouteItem> = [
-  {
-    kind: "route",
-    label: "Catalog",
-    path: "/workspaces",
-    icon: ClusterIcon,
-    title: "Workspaces",
-  },
-];
-
 export const navigationItems: ReadonlyArray<NavigationItem> = [
   { kind: "route", label: "Overview", path: "/", icon: DashboardIcon },
-  {
-    kind: "panel",
-    label: "Workspaces",
-    icon: ClusterIcon,
-    panelId: "workspaces",
-    children: workspacePanelChildren,
-  },
+  { kind: "route", label: "Workspaces", path: "/workspaces", icon: ClusterIcon },
   {
     kind: "route",
     label: "Activity",

--- a/ui/src/routes/activity.tsx
+++ b/ui/src/routes/activity.tsx
@@ -1,38 +1,49 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { Loader } from "@redislabsdev/redis-ui-components";
-import { EventList, PageStack, SectionCard, SectionGrid, SectionTitle } from "../components/afs-kit";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Button, Loader } from "@redislabsdev/redis-ui-components";
+import { PageStack, SectionCard, SectionGrid, SectionHeader, SectionTitle } from "../components/afs-kit";
 import { useActivity } from "../foundation/hooks/use-afs";
+import { ActivityTable } from "../foundation/tables/activity-table";
+import type { AFSActivityEvent } from "../foundation/types/afs";
 
 export const Route = createFileRoute("/activity")({
   component: ActivityPage,
 });
 
 function ActivityPage() {
-  const activityQuery = useActivity(50);
+  const navigate = useNavigate();
+  const activityQuery = useActivity(100);
 
   if (activityQuery.isLoading) {
     return <Loader data-testid="loader--spinner" />;
   }
 
-  const events = (activityQuery.data ?? []).map((event) => ({
-    ...event,
-    title: event.workspaceName ? `${event.workspaceName}: ${event.title}` : event.title,
-  }));
+  const events = activityQuery.data ?? [];
+
+  function openActivity(event: AFSActivityEvent) {
+    if (event.workspaceId == null) {
+      return;
+    }
+
+    void navigate({
+      to: "/workspaces/$workspaceId",
+      params: { workspaceId: event.workspaceId },
+      search: activityDestinationSearch(event),
+    });
+  }
 
   return (
     <PageStack>
-      <SectionGrid>
-        <SectionCard $span={12}>
-          <SectionTitle
-            eyebrow="Audit"
-            title="Workspace activity"
-            body="This page now reads from the control-plane audit feed instead of fanning out through every workspace payload."
-          />
-          <div style={{ marginTop: 16 }}>
-            <EventList events={events} />
-          </div>
-        </SectionCard>
-      </SectionGrid>
+      <ActivityTable rows={events} onOpenActivity={openActivity} />
     </PageStack>
   );
+}
+
+function activityDestinationSearch(event: AFSActivityEvent) {
+  if (event.scope === "savepoint") {
+    return { tab: "checkpoints" as const };
+  }
+  if (event.scope === "file") {
+    return { tab: "files" as const };
+  }
+  return {};
 }

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -1,16 +1,12 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { Button, Loader, Typography } from "@redislabsdev/redis-ui-components";
+import { Button, Loader } from "@redislabsdev/redis-ui-components";
 import styled from "styled-components";
 import {
-  CardHeader,
   EventList,
   HeroBody,
   HeroCard,
   HeroLayout,
-  HeroMetaGrid,
   InlineActions,
-  MetaItem,
-  MetaRow,
   PageStack,
   SectionCard,
   SectionGrid,
@@ -22,17 +18,9 @@ import {
   StatLabel,
   StatValue,
   Tag,
-  ToneChip,
-  WorkspaceCard,
-  WorkspaceGrid,
 } from "../components/afs-kit";
-import { getAFSClientMode, formatBytes } from "../foundation/api/afs";
+import { formatBytes } from "../foundation/api/afs";
 import { useActivity, useWorkspaceSummaries } from "../foundation/hooks/use-afs";
-import type {
-  AFSDraftState,
-  AFSWorkspaceSource,
-  AFSWorkspaceStatus,
-} from "../foundation/types/afs";
 
 export const Route = createFileRoute("/")({
   component: OverviewPage,
@@ -47,136 +35,132 @@ function OverviewPage() {
   }
 
   const workspaces = workspacesQuery.data ?? [];
-  const backendMode = getAFSClientMode();
   const activity = (activityQuery.data ?? []).map((event) => ({
     ...event,
     title: event.workspaceName ? `${event.workspaceName}: ${event.title}` : event.title,
   }));
+
+  if (workspaces.length === 0) {
+    return (
+      <PageStack>
+        <HeroCard>
+          <HeroLayout>
+            <HeroBody>
+              <SectionTitle
+                eyebrow="Getting Started"
+                title="Create your first agent workspace"
+                body="Agent Filesystem gives every agent a durable workspace you can browse in the browser, checkpoint before risky changes, and restore when you need to recover fast. Start blank, import existing work, or register a managed workspace and operate on it from one place."
+              />
+              <InlineActions>
+                <Link to="/workspaces">
+                  <Button size="medium">Add workspace</Button>
+                </Link>
+              </InlineActions>
+              <BenefitGrid>
+                <BenefitCard>
+                  <BenefitKicker>01</BenefitKicker>
+                  <BenefitTitle>Bring in real working state</BenefitTitle>
+                  <BenefitBody>
+                    Start with a blank workspace, a Git import, or a Redis Cloud import instead of rebuilding context by hand.
+                  </BenefitBody>
+                </BenefitCard>
+                <BenefitCard>
+                  <BenefitKicker>02</BenefitKicker>
+                  <BenefitTitle>Edit, inspect, and keep history close</BenefitTitle>
+                  <BenefitBody>
+                    Browse files in the studio, keep mutable state visible, and make checkpoints part of the normal workflow.
+                  </BenefitBody>
+                </BenefitCard>
+                <BenefitCard>
+                  <BenefitKicker>03</BenefitKicker>
+                  <BenefitTitle>Recover without guesswork</BenefitTitle>
+                  <BenefitBody>
+                    Open a workspace and use its checkpoint view to compare history, restore safely, and understand what changed.
+                  </BenefitBody>
+                </BenefitCard>
+              </BenefitGrid>
+            </HeroBody>
+
+            <StarterPanel>
+              <StarterPreview>
+                <StarterCore>Agent Filesystem</StarterCore>
+                <StarterNode $x="8%" $y="14%">
+                  Blank workspace
+                </StarterNode>
+                <StarterNode $x="58%" $y="18%">
+                  Git import
+                </StarterNode>
+                <StarterNode $x="18%" $y="66%">
+                  Browser studio
+                </StarterNode>
+                <StarterNode $x="56%" $y="70%">
+                  Checkpoints
+                </StarterNode>
+              </StarterPreview>
+              <StarterList>
+                <StarterListTitle>What you unlock</StarterListTitle>
+                <StarterListItem>One place to manage durable workspaces for code, prompts, memories, and artifacts.</StarterListItem>
+                <StarterListItem>A clear path from draft edits to saved checkpoints.</StarterListItem>
+                <StarterListItem>A registry, studio, and activity view that stay in sync.</StarterListItem>
+              </StarterList>
+              <StarterTags>
+                <Tag>Blank workspace</Tag>
+                <Tag>Git import</Tag>
+                <Tag>Redis Cloud import</Tag>
+              </StarterTags>
+            </StarterPanel>
+          </HeroLayout>
+        </HeroCard>
+      </PageStack>
+    );
+  }
+
+  const activeWorkspaces = workspaces.filter((workspace) => workspace.status !== "attention").length;
+  const attentionWorkspaces = workspaces.filter((workspace) => workspace.status === "attention").length;
   const dirtyWorkspaces = workspaces.filter((workspace) => workspace.draftState === "dirty").length;
+  const workspacesWithCheckpoints = workspaces.filter((workspace) => workspace.checkpointCount > 0).length;
   const checkpointCount = workspaces.reduce((sum, workspace) => sum + workspace.checkpointCount, 0);
-  const healthyWorkspaces = workspaces.filter((workspace) => workspace.status === "healthy").length;
-  const importedWorkspaces = workspaces.filter((workspace) => workspace.source !== "blank").length;
   const totalBytes = workspaces.reduce((sum, workspace) => sum + workspace.totalBytes, 0);
+  const importedWorkspaces = workspaces.filter((workspace) => workspace.source !== "blank").length;
+  const blankWorkspaces = workspaces.length - importedWorkspaces;
   const regionCount = new Set(workspaces.map((workspace) => workspace.region)).size;
-  const featuredWorkspaces = [...workspaces]
-    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
-    .slice(0, 4);
+  const latestCheckpointAt = workspaces
+    .filter((workspace) => workspace.checkpointCount > 0)
+    .map((workspace) => workspace.lastCheckpointAt)
+    .sort((left, right) => right.localeCompare(left))[0];
+  const largestWorkspace = [...workspaces].sort((left, right) => right.totalBytes - left.totalBytes)[0];
+  const checkpointCoverage = workspaces.length === 0 ? 0 : Math.round((workspacesWithCheckpoints / workspaces.length) * 100);
 
   return (
     <PageStack>
-      <HeroCard>
-        <HeroLayout>
-          <HeroBody>
-            <SectionTitle
-              eyebrow="Filesystem Operations Surface"
-              title="See workspace health, draft pressure, and checkpoint recovery in one console"
-              body="The first screen should immediately answer three questions: what needs attention, where edits are still mutable, and which checkpoint lets you recover without guesswork."
-            />
-            <InlineActions>
-              <Link to="/workspaces">
-                <Button size="medium">Open workspace catalog</Button>
-              </Link>
-              <Link to="/activity">
-                <Button size="medium" variant="secondary-fill">
-                  Review activity feed
-                </Button>
-              </Link>
-            </InlineActions>
-            <FlowGrid>
-              <FlowCard>
-                <FlowStep>01</FlowStep>
-                <FlowTitle>Pick the workspace</FlowTitle>
-                <FlowBody>
-                  Start from fleet health and open the workspace that is drifting, syncing, or ready
-                  for a checkpoint.
-                </FlowBody>
-              </FlowCard>
-              <FlowCard>
-                <FlowStep>02</FlowStep>
-                <FlowTitle>Inspect mutable state</FlowTitle>
-                <FlowBody>
-                  Separate working copy edits from saved head so operators can see whether a change is
-                  tentative or canonical.
-                </FlowBody>
-              </FlowCard>
-              <FlowCard>
-                <FlowStep>03</FlowStep>
-                <FlowTitle>Checkpoint with intent</FlowTitle>
-                <FlowBody>
-                  Every restore or savepoint should feel like a deliberate move in an operational
-                  loop, not an afterthought.
-                </FlowBody>
-              </FlowCard>
-            </FlowGrid>
-          </HeroBody>
-
-          <HeroMetaGrid>
-            <MetaItem>
-              <MetaLabel>Current backend</MetaLabel>
-              <MetaValue>
-                {backendMode === "http" ? "HTTP control plane" : "Local AFS demo store"}
-              </MetaValue>
-              <MetaBody>
-                {backendMode === "http"
-                  ? "The console is reading workspace summaries and activity from the running service."
-                  : "Demo mode stays useful while the live control plane is still being wired up."}
-              </MetaBody>
-            </MetaItem>
-            <MetaItem>
-              <MetaLabel>Mutable pressure</MetaLabel>
-              <MetaValue>{dirtyWorkspaces} dirty workspaces</MetaValue>
-              <MetaBody>
-                Draft state stays visible at the fleet level so it is easy to spot pending edits.
-              </MetaBody>
-            </MetaItem>
-            <MetaItem>
-              <MetaLabel>Checkpoint coverage</MetaLabel>
-              <MetaValue>{checkpointCount} recovery points</MetaValue>
-              <MetaBody>
-                The UI should make rollback confidence feel built in, not hidden behind a workflow.
-              </MetaBody>
-            </MetaItem>
-            <MetaItem>
-              <MetaLabel>Footprint</MetaLabel>
-              <MetaValue>
-                {workspaces.length} workspaces across {regionCount || 0} regions
-              </MetaValue>
-              <MetaBody>Redis-backed filesystems stay legible even as the fleet spreads out.</MetaBody>
-            </MetaItem>
-          </HeroMetaGrid>
-        </HeroLayout>
-      </HeroCard>
-
       <StatGrid>
         <StatCard>
           <div>
-            <StatLabel>Workspace Fleet</StatLabel>
+            <StatLabel>Workspaces</StatLabel>
             <StatValue>{workspaces.length}</StatValue>
           </div>
-          <StatDetail>
-            {healthyWorkspaces} healthy and {dirtyWorkspaces} holding draft edits.
-          </StatDetail>
+          <StatDetail>{activeWorkspaces} active and {attentionWorkspaces} inactive.</StatDetail>
         </StatCard>
         <StatCard>
           <div>
-            <StatLabel>Imported Sources</StatLabel>
-            <StatValue>{importedWorkspaces}</StatValue>
-          </div>
-          <StatDetail>Git and Redis Cloud imports should read as first-class entry paths.</StatDetail>
-        </StatCard>
-        <StatCard>
-          <div>
-            <StatLabel>Stored Content</StatLabel>
+            <StatLabel>Stored Data</StatLabel>
             <StatValue>{formatBytes(totalBytes)}</StatValue>
           </div>
-          <StatDetail>Size is useful when a workspace becomes a long-lived memory or artifact set.</StatDetail>
+          <StatDetail>Total durable content tracked across all workspaces.</StatDetail>
         </StatCard>
         <StatCard>
           <div>
-            <StatLabel>Recovery Depth</StatLabel>
+            <StatLabel>Checkpoints Created</StatLabel>
             <StatValue>{checkpointCount}</StatValue>
           </div>
-          <StatDetail>Checkpoint history should stay close to the live editing surface.</StatDetail>
+          <StatDetail>{checkpointCoverage}% of workspaces currently have checkpoint history.</StatDetail>
+        </StatCard>
+        <StatCard>
+          <div>
+            <StatLabel>Attention Needed</StatLabel>
+            <StatValue>{attentionWorkspaces + dirtyWorkspaces}</StatValue>
+          </div>
+          <StatDetail>{dirtyWorkspaces} workspace{dirtyWorkspaces === 1 ? "" : "s"} currently carrying draft changes.</StatDetail>
         </StatCard>
       </StatGrid>
 
@@ -184,65 +168,60 @@ function OverviewPage() {
         <SectionCard $span={7}>
           <SectionHeader>
             <SectionTitle
-              eyebrow="Fleet Signals"
-              title="Hot workspaces"
-              body="These cards should feel like operational readouts: source, mutable state, content footprint, and the Redis mapping you will touch if you open the studio."
+              eyebrow="Health"
+              title=""
             />
           </SectionHeader>
-          <WorkspaceGrid>
-            {featuredWorkspaces.map((workspace) => (
-              <WorkspaceCard key={workspace.id}>
-                <CardHeader>
-                  <div>
-                    <Typography.Heading component="h3" size="S">
-                      {workspace.name}
-                    </Typography.Heading>
-                    <Typography.Body color="secondary" component="p">
-                      {workspace.databaseName} · {workspace.redisKey}
-                    </Typography.Body>
-                  </div>
-                  <ToneChip $tone={workspace.status}>{statusLabel(workspace.status)}</ToneChip>
-                </CardHeader>
-                <InlineActions>
-                  <ToneChip $tone={workspace.draftState}>
-                    {draftStateLabel(workspace.draftState)}
-                  </ToneChip>
-                  <ToneChip $tone={workspace.source}>{sourceLabel(workspace.source)}</ToneChip>
-                </InlineActions>
-                <WorkspaceFacts>
-                  <FactTile>
-                    <FactLabel>Content</FactLabel>
-                    <FactValue>{workspace.fileCount} files</FactValue>
-                  </FactTile>
-                  <FactTile>
-                    <FactLabel>Footprint</FactLabel>
-                    <FactValue>{formatBytes(workspace.totalBytes)}</FactValue>
-                  </FactTile>
-                  <FactTile>
-                    <FactLabel>Checkpoints</FactLabel>
-                    <FactValue>{workspace.checkpointCount}</FactValue>
-                  </FactTile>
-                  <FactTile>
-                    <FactLabel>Updated</FactLabel>
-                    <FactValue>{new Date(workspace.updatedAt).toLocaleDateString()}</FactValue>
-                  </FactTile>
-                </WorkspaceFacts>
-                <MetaRow>
-                  <Tag>{workspace.region}</Tag>
-                  <Tag>{workspace.folderCount} folders</Tag>
-                  <Tag>{new Date(workspace.lastCheckpointAt).toLocaleDateString()}</Tag>
-                </MetaRow>
-              </WorkspaceCard>
-            ))}
-          </WorkspaceGrid>
+          <SignalList>
+            <SignalRow>
+              <SignalText>
+                <SignalTitle>Active workspaces</SignalTitle>
+                <SignalBody>Healthy and syncing workspaces that are currently in rotation.</SignalBody>
+              </SignalText>
+              <SignalMetric>{activeWorkspaces}</SignalMetric>
+              <SignalBar>
+                <SignalFill $value={ratio(activeWorkspaces, workspaces.length)} />
+              </SignalBar>
+            </SignalRow>
+            <SignalRow>
+              <SignalText>
+                <SignalTitle>Inactive workspaces</SignalTitle>
+                <SignalBody>Workspaces that need attention before they should be trusted as ready.</SignalBody>
+              </SignalText>
+              <SignalMetric>{attentionWorkspaces}</SignalMetric>
+              <SignalBar>
+                <SignalFill $value={ratio(attentionWorkspaces, workspaces.length)} />
+              </SignalBar>
+            </SignalRow>
+            <SignalRow>
+              <SignalText>
+                <SignalTitle>Dirty working state</SignalTitle>
+                <SignalBody>Workspaces carrying draft changes that have not been checkpointed yet.</SignalBody>
+              </SignalText>
+              <SignalMetric>{dirtyWorkspaces}</SignalMetric>
+              <SignalBar>
+                <SignalFill $value={ratio(dirtyWorkspaces, workspaces.length)} />
+              </SignalBar>
+            </SignalRow>
+            <SignalRow>
+              <SignalText>
+                <SignalTitle>Checkpoint coverage</SignalTitle>
+                <SignalBody>Workspaces with at least one checkpoint already recorded.</SignalBody>
+              </SignalText>
+              <SignalMetric>{workspacesWithCheckpoints}</SignalMetric>
+              <SignalBar>
+                <SignalFill $value={ratio(workspacesWithCheckpoints, workspaces.length)} />
+              </SignalBar>
+            </SignalRow>
+          </SignalList>
         </SectionCard>
 
         <SectionCard $span={5}>
           <SectionHeader>
             <SectionTitle
-              eyebrow="Audit Pulse"
-              title="Recent activity"
-              body="The event feed is the fastest way to validate that the console reflects real Redis-backed mutations."
+              eyebrow="Recent Activity"
+              title="Latest activity"
+              body="Recent activity belongs on the overview as a quick confidence check that the registry, studio, and audit feed are all moving together."
             />
           </SectionHeader>
           <EventList events={activity} />
@@ -250,219 +229,104 @@ function OverviewPage() {
       </SectionGrid>
 
       <SectionGrid>
-        <SectionCard $span={4}>
-          <SectionTitle
-            eyebrow="Operator Loop"
-            title="What this UI should make obvious"
-            body="The console is working when these decisions require almost no interpretation from the operator."
-          />
-          <Checklist>
-            <ChecklistItem>
-              <ChecklistTitle>Which state is canonical?</ChecklistTitle>
-              <ChecklistBody>Saved head, working copy, and checkpoints must read as clearly distinct views.</ChecklistBody>
-            </ChecklistItem>
-            <ChecklistItem>
-              <ChecklistTitle>Can I safely roll back?</ChecklistTitle>
-              <ChecklistBody>Recovery actions should always be adjacent to the history they affect.</ChecklistBody>
-            </ChecklistItem>
-            <ChecklistItem>
-              <ChecklistTitle>What changed recently?</ChecklistTitle>
-              <ChecklistBody>The audit trail belongs in the same visual language as file and checkpoint work.</ChecklistBody>
-            </ChecklistItem>
-          </Checklist>
+        <SectionCard $span={6}>
+          <SectionHeader>
+            <SectionTitle
+              eyebrow="Recovery"
+              title="Checkpoint readiness"
+              body="Checkpoint data is most useful when it is summarized as readiness, not buried inside an individual workspace."
+            />
+          </SectionHeader>
+          <HighlightGrid>
+            <HighlightCard>
+              <HighlightLabel>Coverage</HighlightLabel>
+              <HighlightValue>{checkpointCoverage}%</HighlightValue>
+              <HighlightBody>Workspaces already carrying checkpoint history.</HighlightBody>
+            </HighlightCard>
+            <HighlightCard>
+              <HighlightLabel>Without checkpoints</HighlightLabel>
+              <HighlightValue>{workspaces.length - workspacesWithCheckpoints}</HighlightValue>
+              <HighlightBody>Workspaces that should create their first recovery point.</HighlightBody>
+            </HighlightCard>
+            <HighlightCard>
+              <HighlightLabel>Average depth</HighlightLabel>
+              <HighlightValue>
+                {workspaces.length === 0 ? "0.0" : (checkpointCount / workspaces.length).toFixed(1)}
+              </HighlightValue>
+              <HighlightBody>Average number of checkpoints per workspace.</HighlightBody>
+            </HighlightCard>
+            <HighlightCard>
+              <HighlightLabel>Latest checkpoint</HighlightLabel>
+              <HighlightValue>
+                {latestCheckpointAt ? new Date(latestCheckpointAt).toLocaleDateString() : "n/a"}
+              </HighlightValue>
+              <HighlightBody>Most recent checkpoint creation time across the fleet.</HighlightBody>
+            </HighlightCard>
+          </HighlightGrid>
         </SectionCard>
 
-        <SectionCard $span={8}>
-          <SectionTitle
-            eyebrow="Studio Intent"
-            title="The three surfaces to reinforce"
-            body="Every route in the UI can ladder back to these product truths, which keeps the design opinionated instead of drifting toward generic admin chrome."
-          />
-          <InsightGrid>
-            <InsightCard>
-              <InsightKicker>Canonical State</InsightKicker>
-              <InsightTitle>Redis-backed head is the stable reference point</InsightTitle>
-              <InsightBody>
-                The saved head should feel like the trustworthy baseline operators compare everything
-                else against.
-              </InsightBody>
-            </InsightCard>
-            <InsightCard>
-              <InsightKicker>Mutable State</InsightKicker>
-              <InsightTitle>Working copy edits are live, visible, and intentionally temporary</InsightTitle>
-              <InsightBody>
-                Dirty draft state needs visual tension so in-progress edits are noticeable without
-                looking like errors.
-              </InsightBody>
-            </InsightCard>
-            <InsightCard>
-              <InsightKicker>Recovery State</InsightKicker>
-              <InsightTitle>Checkpoint history should feel like an instrument panel</InsightTitle>
-              <InsightBody>
-                Recovery points earn trust when the UI makes them tangible, recent, and easy to
-                compare against the current workspace.
-              </InsightBody>
-            </InsightCard>
-          </InsightGrid>
+        <SectionCard $span={6}>
+          <SectionHeader>
+            <SectionTitle
+              eyebrow="Posture"
+              title="Workspace mix"
+              body="A compact mix view helps you see how the registry is composed without turning Overview into another catalog."
+            />
+          </SectionHeader>
+          <HighlightGrid>
+            <HighlightCard>
+              <HighlightLabel>Imported</HighlightLabel>
+              <HighlightValue>{importedWorkspaces}</HighlightValue>
+              <HighlightBody>Workspaces brought in from Git or Redis Cloud.</HighlightBody>
+            </HighlightCard>
+            <HighlightCard>
+              <HighlightLabel>Blank</HighlightLabel>
+              <HighlightValue>{blankWorkspaces}</HighlightValue>
+              <HighlightBody>Workspaces created directly inside Agent Filesystem.</HighlightBody>
+            </HighlightCard>
+            <HighlightCard>
+              <HighlightLabel>Regions</HighlightLabel>
+              <HighlightValue>{regionCount}</HighlightValue>
+              <HighlightBody>Distinct regions represented in the current registry.</HighlightBody>
+            </HighlightCard>
+            <HighlightCard>
+              <HighlightLabel>Largest workspace</HighlightLabel>
+              <HighlightValue>{formatBytes(largestWorkspace.totalBytes)}</HighlightValue>
+              <HighlightBody>{largestWorkspace.name}</HighlightBody>
+            </HighlightCard>
+          </HighlightGrid>
         </SectionCard>
       </SectionGrid>
     </PageStack>
   );
 }
 
-function statusLabel(status: AFSWorkspaceStatus) {
-  if (status === "healthy") return "Healthy";
-  if (status === "syncing") return "Syncing";
-  return "Attention";
+function ratio(value: number, total: number) {
+  if (total <= 0 || value <= 0) {
+    return 0;
+  }
+
+  return Math.max(8, Math.min(100, Math.round((value / total) * 100)));
 }
 
-function draftStateLabel(state: AFSDraftState) {
-  return state === "dirty" ? "Draft dirty" : "Draft clean";
-}
-
-function sourceLabel(source: AFSWorkspaceSource) {
-  if (source === "git-import") return "Git import";
-  if (source === "cloud-import") return "Cloud import";
-  return "Blank";
-}
-
-const FlowGrid = styled.div`
+const BenefitGrid = styled.div`
   display: grid;
   gap: 12px;
   grid-template-columns: repeat(3, minmax(0, 1fr));
 
-  @media (max-width: 860px) {
+  @media (max-width: 900px) {
     grid-template-columns: 1fr;
   }
 `;
 
-const FlowCard = styled.div`
+const BenefitCard = styled.div`
   border: 1px solid var(--afs-line);
   border-radius: 20px;
   padding: 16px 18px;
   background: rgba(255, 255, 255, 0.78);
 `;
 
-const FlowStep = styled.div`
-  color: var(--afs-amber);
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-`;
-
-const FlowTitle = styled.div`
-  margin-top: 10px;
-  color: var(--afs-ink);
-  font-size: 15px;
-  font-weight: 700;
-`;
-
-const FlowBody = styled.p`
-  margin: 8px 0 0;
-  color: var(--afs-muted);
-  font-size: 14px;
-  line-height: 1.6;
-`;
-
-const MetaLabel = styled.span`
-  color: var(--afs-muted);
-  font-size: 11px;
-  font-weight: 800;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-`;
-
-const MetaValue = styled.span`
-  color: var(--afs-ink);
-  font-size: 1.1rem;
-  font-weight: 700;
-  line-height: 1.35;
-`;
-
-const MetaBody = styled.p`
-  margin: 0;
-  color: var(--afs-muted);
-  font-size: 14px;
-  line-height: 1.6;
-`;
-
-const WorkspaceFacts = styled.div`
-  display: grid;
-  gap: 10px;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  margin-top: 16px;
-`;
-
-const FactTile = styled.div`
-  border-radius: 18px;
-  padding: 12px 14px;
-  background: rgba(255, 255, 255, 0.74);
-  border: 1px solid var(--afs-line);
-`;
-
-const FactLabel = styled.div`
-  color: var(--afs-muted);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-`;
-
-const FactValue = styled.div`
-  margin-top: 6px;
-  color: var(--afs-ink);
-  font-size: 14px;
-  font-weight: 700;
-`;
-
-const Checklist = styled.div`
-  display: grid;
-  gap: 12px;
-  margin-top: 18px;
-`;
-
-const ChecklistItem = styled.div`
-  border: 1px solid var(--afs-line);
-  border-radius: 18px;
-  padding: 16px;
-  background: rgba(255, 255, 255, 0.74);
-`;
-
-const ChecklistTitle = styled.div`
-  color: var(--afs-ink);
-  font-size: 15px;
-  font-weight: 700;
-`;
-
-const ChecklistBody = styled.p`
-  margin: 8px 0 0;
-  color: var(--afs-muted);
-  font-size: 14px;
-  line-height: 1.6;
-`;
-
-const InsightGrid = styled.div`
-  display: grid;
-  gap: 12px;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  margin-top: 18px;
-
-  @media (max-width: 960px) {
-    grid-template-columns: 1fr;
-  }
-`;
-
-const InsightCard = styled.div`
-  border: 1px solid var(--afs-line);
-  border-radius: 22px;
-  padding: 18px;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.84), rgba(243, 246, 251, 0.92)),
-    rgba(255, 255, 255, 0.8);
-`;
-
-const InsightKicker = styled.div`
+const BenefitKicker = styled.div`
   color: var(--afs-accent);
   font-size: 11px;
   font-weight: 800;
@@ -470,15 +334,201 @@ const InsightKicker = styled.div`
   text-transform: uppercase;
 `;
 
-const InsightTitle = styled.div`
+const BenefitTitle = styled.div`
   margin-top: 10px;
   color: var(--afs-ink);
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 700;
   line-height: 1.45;
 `;
 
-const InsightBody = styled.p`
+const BenefitBody = styled.p`
+  margin: 8px 0 0;
+  color: var(--afs-muted);
+  font-size: 14px;
+  line-height: 1.65;
+`;
+
+const StarterPanel = styled.div`
+  display: grid;
+  gap: 14px;
+  border: 1px solid var(--afs-line);
+  border-radius: 24px;
+  padding: 18px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.84), rgba(243, 246, 251, 0.92)),
+    rgba(255, 255, 255, 0.86);
+`;
+
+const StarterPreview = styled.div`
+  position: relative;
+  min-height: 230px;
+  border-radius: 22px;
+  border: 1px solid var(--afs-line);
+  background:
+    radial-gradient(circle at center, rgba(170, 59, 255, 0.12), transparent 48%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(246, 249, 255, 0.92));
+  overflow: hidden;
+`;
+
+const StarterCore = styled.div`
+  position: absolute;
+  inset: 50% auto auto 50%;
+  transform: translate(-50%, -50%);
+  min-width: 168px;
+  padding: 16px 18px;
+  border-radius: 20px;
+  text-align: center;
+  border: 1px solid var(--afs-line-strong);
+  background: #fff;
+  color: var(--afs-ink);
+  font-size: 15px;
+  font-weight: 700;
+  box-shadow: 0 14px 28px rgba(8, 6, 13, 0.08);
+`;
+
+const StarterNode = styled.div<{ $x: string; $y: string }>`
+  position: absolute;
+  left: ${({ $x }) => $x};
+  top: ${({ $y }) => $y};
+  padding: 10px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--afs-line);
+  background: rgba(255, 255, 255, 0.94);
+  color: var(--afs-ink-soft);
+  font-size: 12px;
+  font-weight: 700;
+`;
+
+const StarterList = styled.div`
+  display: grid;
+  gap: 10px;
+`;
+
+const StarterListTitle = styled.div`
+  color: var(--afs-ink);
+  font-size: 15px;
+  font-weight: 700;
+`;
+
+const StarterListItem = styled.div`
+  position: relative;
+  padding-left: 18px;
+  color: var(--afs-muted);
+  font-size: 14px;
+  line-height: 1.65;
+
+  &::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 9px;
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: var(--afs-accent);
+  }
+`;
+
+const StarterTags = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+const SignalList = styled.div`
+  display: grid;
+  gap: 14px;
+`;
+
+const SignalRow = styled.div`
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(0, 1.4fr) auto minmax(120px, 180px);
+  align-items: center;
+  border: 1px solid var(--afs-line);
+  border-radius: 20px;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.78);
+
+  @media (max-width: 860px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const SignalText = styled.div`
+  display: grid;
+  gap: 6px;
+`;
+
+const SignalTitle = styled.div`
+  color: var(--afs-ink);
+  font-size: 15px;
+  font-weight: 700;
+`;
+
+const SignalBody = styled.p`
+  margin: 0;
+  color: var(--afs-muted);
+  font-size: 14px;
+  line-height: 1.6;
+`;
+
+const SignalMetric = styled.div`
+  color: var(--afs-ink);
+  font-size: 1.8rem;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+`;
+
+const SignalBar = styled.div`
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(8, 6, 13, 0.08);
+  overflow: hidden;
+`;
+
+const SignalFill = styled.div<{ $value: number }>`
+  width: ${({ $value }) => `${$value}%`};
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #aa3bff, #47bfff);
+`;
+
+const HighlightGrid = styled.div`
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+
+  @media (max-width: 720px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const HighlightCard = styled.div`
+  border: 1px solid var(--afs-line);
+  border-radius: 20px;
+  padding: 18px;
+  background: rgba(255, 255, 255, 0.78);
+`;
+
+const HighlightLabel = styled.div`
+  color: var(--afs-muted);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+`;
+
+const HighlightValue = styled.div`
+  margin-top: 10px;
+  color: var(--afs-ink);
+  font-size: 1.9rem;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+`;
+
+const HighlightBody = styled.p`
   margin: 8px 0 0;
   color: var(--afs-muted);
   font-size: 14px;

--- a/ui/src/routes/workspaces.$workspaceId.tsx
+++ b/ui/src/routes/workspaces.$workspaceId.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Button, Loader, Typography } from "@redislabsdev/redis-ui-components";
 import { useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
+import { z } from "zod";
 import {
   CardHeader,
   EditorArea,
@@ -44,7 +45,9 @@ import {
   useWorkspaceFileContent,
   useWorkspaceTree,
 } from "../foundation/hooks/use-afs";
+import { ActivityTable } from "../foundation/tables/activity-table";
 import type {
+  AFSActivityEvent,
   AFSDraftState,
   AFSWorkspaceDetail,
   AFSWorkspaceSource,
@@ -52,22 +55,27 @@ import type {
   AFSWorkspaceView,
 } from "../foundation/types/afs";
 
-type StudioTab = "overview" | "files" | "activity";
+type StudioTab = "overview" | "files" | "checkpoints" | "activity";
+
+const workspaceStudioSearchSchema = z.object({
+  tab: z.enum(["overview", "files", "checkpoints", "activity"]).optional(),
+});
 
 export const Route = createFileRoute("/workspaces/$workspaceId")({
+  validateSearch: workspaceStudioSearchSchema,
   component: WorkspaceStudioPage,
 });
 
 function WorkspaceStudioPage() {
   const navigate = useNavigate();
   const { workspaceId } = Route.useParams();
+  const search = Route.useSearch();
   const workspaceQuery = useWorkspace(workspaceId);
   const deleteWorkspace = useDeleteWorkspaceMutation();
   const updateFile = useUpdateWorkspaceFileMutation();
   const createSavepoint = useCreateSavepointMutation();
   const restoreSavepoint = useRestoreSavepointMutation();
 
-  const [tab, setTab] = useState<StudioTab>("overview");
   const [browserView, setBrowserView] = useState<AFSWorkspaceView>("head");
   const [currentPath, setCurrentPath] = useState("/");
   const [selectedPath, setSelectedPath] = useState("");
@@ -77,6 +85,7 @@ function WorkspaceStudioPage() {
   const [rollbackTarget, setRollbackTarget] = useState("");
 
   const workspace = workspaceQuery.data;
+  const tab = search.tab ?? "overview";
   const activeSavepoint =
     workspace?.savepoints.find((savepoint) => savepoint.id === workspace.headSavepointId) ?? null;
 
@@ -143,6 +152,15 @@ function WorkspaceStudioPage() {
   );
   const lastActivity = workspace?.activity[0] ?? null;
   const tabCopy = describeTab(tab);
+
+  function setStudioTab(nextTab: StudioTab) {
+    void navigate({
+      to: "/workspaces/$workspaceId",
+      params: { workspaceId },
+      search: nextTab === "overview" ? {} : { tab: nextTab },
+      replace: true,
+    });
+  }
 
   if (workspaceQuery.isLoading) {
     return <Loader data-testid="loader--spinner" />;
@@ -254,13 +272,16 @@ function WorkspaceStudioPage() {
             <SectionTitle eyebrow="Studio Views" title={tabCopy.title} body={tabCopy.body} />
           </SectionHeader>
           <Tabs>
-            <TabButton $active={tab === "overview"} onClick={() => setTab("overview")}>
+            <TabButton $active={tab === "overview"} onClick={() => setStudioTab("overview")}>
               Overview
             </TabButton>
-            <TabButton $active={tab === "files"} onClick={() => setTab("files")}>
+            <TabButton $active={tab === "files"} onClick={() => setStudioTab("files")}>
               Files
             </TabButton>
-            <TabButton $active={tab === "activity"} onClick={() => setTab("activity")}>
+            <TabButton $active={tab === "checkpoints"} onClick={() => setStudioTab("checkpoints")}>
+              Checkpoints
+            </TabButton>
+            <TabButton $active={tab === "activity"} onClick={() => setStudioTab("activity")}>
               Activity
             </TabButton>
           </Tabs>
@@ -274,7 +295,7 @@ function WorkspaceStudioPage() {
               <SectionHeader>
                 <SectionTitle
                   title="Workspace state"
-                  body="These are the signals an operator needs before browsing files or restoring a checkpoint."
+                  body="These are the signals an operator needs before opening files or stepping into checkpoint work."
                 />
               </SectionHeader>
               <StateGrid>
@@ -305,8 +326,46 @@ function WorkspaceStudioPage() {
             <SectionCard $span={8}>
               <SectionHeader>
                 <SectionTitle
+                  title="Capability surface"
+                  body="Capability flags tell the UI which surfaces are live controls versus read-only inspection points."
+                />
+              </SectionHeader>
+              <CapabilityGrid>
+                {capabilityCards.map((capability) => (
+                  <CapabilityCard key={capability.title} $enabled={capability.enabled}>
+                    <CapabilityStatus $enabled={capability.enabled}>
+                      {capability.enabled ? "Enabled" : "Unavailable"}
+                    </CapabilityStatus>
+                    <CapabilityTitle>{capability.title}</CapabilityTitle>
+                    <CapabilityBody>{capability.body}</CapabilityBody>
+                  </CapabilityCard>
+                ))}
+              </CapabilityGrid>
+            </SectionCard>
+          </SectionGrid>
+
+          <SectionGrid>
+            <SectionCard $span={12}>
+              <SectionHeader>
+                <SectionTitle
+                  title="Recent motion"
+                  body="A short activity preview keeps the latest workspace changes adjacent to the state summary."
+                />
+              </SectionHeader>
+              <EventList events={workspace.activity.slice(0, 5)} />
+            </SectionCard>
+          </SectionGrid>
+        </>
+      ) : null}
+
+      {tab === "checkpoints" ? (
+        <>
+          <SectionGrid>
+            <SectionCard $span={8}>
+              <SectionHeader>
+                <SectionTitle
                   title="Checkpoint history"
-                  body="Recovery points are immutable. The studio should make it easy to compare them and promote one back to head."
+                  body="Recovery points live under each workspace so you can compare history, browse older state, and restore with confidence."
                 />
               </SectionHeader>
               <SavepointGrid>
@@ -329,6 +388,20 @@ function WorkspaceStudioPage() {
                       <Button
                         size="medium"
                         variant="secondary-fill"
+                        onClick={() => {
+                          setBrowserView(
+                            savepoint.id === workspace.headSavepointId
+                              ? "head"
+                              : `checkpoint:${savepoint.id}`,
+                          );
+                          setStudioTab("files");
+                        }}
+                      >
+                        Browse
+                      </Button>
+                      <Button
+                        size="medium"
+                        variant="secondary-fill"
                         disabled={
                           !workspace.capabilities.restoreCheckpoint ||
                           restoreSavepoint.isPending ||
@@ -348,37 +421,132 @@ function WorkspaceStudioPage() {
                 ))}
               </SavepointGrid>
             </SectionCard>
+
+            <SectionCard $span={4}>
+              <SectionHeader>
+                <SectionTitle
+                  title="Checkpoint summary"
+                  body="The most useful checkpoint facts should be visible before you choose restore or browse."
+                />
+              </SectionHeader>
+              <StateGrid>
+                <StateCard>
+                  <StateLabel>Checkpoints</StateLabel>
+                  <StateValue>{workspace.savepoints.length}</StateValue>
+                </StateCard>
+                <StateCard>
+                  <StateLabel>Current head</StateLabel>
+                  <StateValue>{activeSavepoint?.name ?? "None"}</StateValue>
+                </StateCard>
+                <StateCard>
+                  <StateLabel>Latest checkpoint</StateLabel>
+                  <StateValue>
+                    {workspace.savepoints[0]
+                      ? new Date(workspace.savepoints[0].createdAt).toLocaleString()
+                      : "n/a"}
+                  </StateValue>
+                </StateCard>
+                <StateCard>
+                  <StateLabel>Restore</StateLabel>
+                  <StateValue>
+                    {workspace.capabilities.restoreCheckpoint ? "Available" : "Unavailable"}
+                  </StateValue>
+                </StateCard>
+              </StateGrid>
+            </SectionCard>
           </SectionGrid>
 
           <SectionGrid>
-            <SectionCard $span={7}>
+            <SectionCard $span={12}>
               <SectionHeader>
                 <SectionTitle
-                  title="Capability surface"
-                  body="Capability flags tell the UI which parts of the studio should present as live controls versus view-only instrumentation."
+                  title="Checkpoint actions"
+                  body="Create and restore checkpoints here so recovery work stays in one dedicated view."
                 />
               </SectionHeader>
-              <CapabilityGrid>
-                {capabilityCards.map((capability) => (
-                  <CapabilityCard key={capability.title} $enabled={capability.enabled}>
-                    <CapabilityStatus $enabled={capability.enabled}>
-                      {capability.enabled ? "Enabled" : "Unavailable"}
-                    </CapabilityStatus>
-                    <CapabilityTitle>{capability.title}</CapabilityTitle>
-                    <CapabilityBody>{capability.body}</CapabilityBody>
-                  </CapabilityCard>
-                ))}
-              </CapabilityGrid>
-            </SectionCard>
+              <ActionStack>
+                <Field>
+                  Restore target
+                  <Select
+                    value={rollbackTarget}
+                    onChange={(event) => setRollbackTarget(event.target.value)}
+                  >
+                    {workspace.savepoints.map((savepoint) => (
+                      <option key={savepoint.id} value={savepoint.id}>
+                        {savepoint.name}
+                      </option>
+                    ))}
+                  </Select>
+                </Field>
+                <InlineActions>
+                  <Button
+                    size="medium"
+                    variant="secondary-fill"
+                    disabled={
+                      !workspace.capabilities.restoreCheckpoint ||
+                      restoreSavepoint.isPending ||
+                      rollbackTarget === workspace.headSavepointId
+                    }
+                    onClick={() =>
+                      restoreSavepoint.mutate({
+                        workspaceId: workspace.id,
+                        savepointId: rollbackTarget,
+                      })
+                    }
+                  >
+                    Restore checkpoint
+                  </Button>
+                </InlineActions>
 
-            <SectionCard $span={5}>
-              <SectionHeader>
-                <SectionTitle
-                  title="Recent motion"
-                  body="A short audit preview keeps recent workspace activity adjacent to state and checkpoint context."
-                />
-              </SectionHeader>
-              <EventList events={workspace.activity.slice(0, 3)} />
+                {workspace.capabilities.createCheckpoint ? (
+                  <FormGrid
+                    onSubmit={(event) => {
+                      event.preventDefault();
+                      if (savepointName.trim() === "") {
+                        return;
+                      }
+
+                      createSavepoint.mutate({
+                        workspaceId: workspace.id,
+                        name: savepointName,
+                        note: savepointNote,
+                      });
+                      setSavepointName("");
+                      setSavepointNote("");
+                    }}
+                  >
+                    <Field>
+                      Checkpoint name
+                      <TextInput
+                        value={savepointName}
+                        onChange={(event) => setSavepointName(event.target.value)}
+                        placeholder="after-editor-pass"
+                      />
+                    </Field>
+                    <Field>
+                      Checkpoint note
+                      <TextArea
+                        value={savepointNote}
+                        onChange={(event) => setSavepointNote(event.target.value)}
+                        placeholder="Why this checkpoint exists."
+                      />
+                    </Field>
+                    <Button
+                      size="medium"
+                      variant="secondary-fill"
+                      type="submit"
+                      disabled={createSavepoint.isPending}
+                    >
+                      Create checkpoint
+                    </Button>
+                  </FormGrid>
+                ) : (
+                  <PanelNote>
+                    Checkpoint creation is unavailable in this transport because it needs a connected
+                    working copy rather than canonical saved state alone.
+                  </PanelNote>
+                )}
+              </ActionStack>
             </SectionCard>
           </SectionGrid>
         </>
@@ -588,11 +756,11 @@ function WorkspaceStudioPage() {
           </SectionGrid>
 
           <SectionGrid>
-            <SectionCard $span={5}>
+            <SectionCard $span={12}>
               <SectionHeader>
                 <SectionTitle
                   title="Current view"
-                  body="The browser keeps working copy, saved head, and checkpoints visually distinct so operators know what they are looking at."
+                  body="The browser keeps working copy, saved head, and checkpoints visually distinct so operators know what they are looking at. Restore and checkpoint creation live in the dedicated checkpoint tab."
                 />
               </SectionHeader>
               <StateGrid>
@@ -614,98 +782,6 @@ function WorkspaceStudioPage() {
                 </StateCard>
               </StateGrid>
             </SectionCard>
-
-            <SectionCard $span={7}>
-              <SectionHeader>
-                <SectionTitle
-                  title="Checkpoint actions"
-                  body="Restore stays close to the browser because operators often need to compare state before and after intervention."
-                />
-              </SectionHeader>
-              <ActionStack>
-                <Field>
-                  Restore target
-                  <Select
-                    value={rollbackTarget}
-                    onChange={(event) => setRollbackTarget(event.target.value)}
-                  >
-                    {workspace.savepoints.map((savepoint) => (
-                      <option key={savepoint.id} value={savepoint.id}>
-                        {savepoint.name}
-                      </option>
-                    ))}
-                  </Select>
-                </Field>
-                <InlineActions>
-                  <Button
-                    size="medium"
-                    variant="secondary-fill"
-                    disabled={
-                      !workspace.capabilities.restoreCheckpoint ||
-                      restoreSavepoint.isPending ||
-                      rollbackTarget === workspace.headSavepointId
-                    }
-                    onClick={() =>
-                      restoreSavepoint.mutate({
-                        workspaceId: workspace.id,
-                        savepointId: rollbackTarget,
-                      })
-                    }
-                  >
-                    Restore checkpoint
-                  </Button>
-                </InlineActions>
-
-                {workspace.capabilities.createCheckpoint ? (
-                  <FormGrid
-                    onSubmit={(event) => {
-                      event.preventDefault();
-                      if (savepointName.trim() === "") {
-                        return;
-                      }
-
-                      createSavepoint.mutate({
-                        workspaceId: workspace.id,
-                        name: savepointName,
-                        note: savepointNote,
-                      });
-                      setSavepointName("");
-                      setSavepointNote("");
-                    }}
-                  >
-                    <Field>
-                      Checkpoint name
-                      <TextInput
-                        value={savepointName}
-                        onChange={(event) => setSavepointName(event.target.value)}
-                        placeholder="after-editor-pass"
-                      />
-                    </Field>
-                    <Field>
-                      Checkpoint note
-                      <TextArea
-                        value={savepointNote}
-                        onChange={(event) => setSavepointNote(event.target.value)}
-                        placeholder="Why this checkpoint exists."
-                      />
-                    </Field>
-                    <Button
-                      size="medium"
-                      variant="secondary-fill"
-                      type="submit"
-                      disabled={createSavepoint.isPending}
-                    >
-                      Create checkpoint
-                    </Button>
-                  </FormGrid>
-                ) : (
-                  <PanelNote>
-                    Checkpoint creation is unavailable in this transport because it needs a connected
-                    working copy rather than canonical saved state alone.
-                  </PanelNote>
-                )}
-              </ActionStack>
-            </SectionCard>
           </SectionGrid>
         </>
       ) : null}
@@ -716,10 +792,13 @@ function WorkspaceStudioPage() {
             <SectionHeader>
               <SectionTitle
                 title="Workspace activity"
-                body="Per-workspace activity reads as an audit lane for file edits, checkpoint creation, and imports."
+                body="Per-workspace activity should be sortable and actionable so operators can jump straight to the relevant surface."
               />
             </SectionHeader>
-            <EventList events={workspace.activity} />
+            <ActivityTable
+              rows={workspace.activity}
+              onOpenActivity={(event) => setStudioTab(activityDestinationTab(event))}
+            />
           </SectionCard>
           <SectionCard $span={4}>
             <SectionHeader>
@@ -862,11 +941,31 @@ function buildCapabilityCards(workspace: AFSWorkspaceDetail) {
   ];
 }
 
+function activityDestinationTab(event: AFSActivityEvent): StudioTab {
+  if (event.scope === "savepoint") {
+    return "checkpoints";
+  }
+  if (event.scope === "file") {
+    return "files";
+  }
+  if (event.scope === "workspace") {
+    return "overview";
+  }
+  return "activity";
+}
+
 function describeTab(tab: StudioTab) {
   if (tab === "files") {
     return {
       title: "Filesystem browser and editor",
       body: "File browsing should feel instrumented, with clear separation between saved views and mutable draft edits.",
+    };
+  }
+
+  if (tab === "checkpoints") {
+    return {
+      title: "Checkpoint history and restore",
+      body: "Checkpoint work belongs in its own view so recovery history, restore actions, and new savepoints stay together.",
     };
   }
 

--- a/ui/src/routes/workspaces.tsx
+++ b/ui/src/routes/workspaces.tsx
@@ -1,246 +1,581 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { Button, Loader } from "@redislabsdev/redis-ui-components";
-import { useState } from "react";
+import { Button, Loader, Typography } from "@redislabsdev/redis-ui-components";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 import {
+  CardHeader,
+  EditorArea,
+  EditorPanel,
   Field,
+  FileButton,
+  FileList,
   FormGrid,
   PageStack,
-  SectionCard,
-  SectionGrid,
-  SectionHeader,
   SectionTitle,
   Select,
-  StatCard,
-  StatDetail,
-  StatGrid,
-  StatLabel,
-  StatValue,
   TextArea,
   TextInput,
   TwoColumnFields,
 } from "../components/afs-kit";
-import { WorkspaceTable } from "../foundation/tables/workspace-table";
 import {
   useCreateWorkspaceMutation,
+  useDeleteWorkspaceMutation,
+  useWorkspaceFileContent,
+  useWorkspaceTree,
+  useUpdateWorkspaceMutation,
+  useWorkspace,
   useWorkspaceSummaries,
 } from "../foundation/hooks/use-afs";
-import type { AFSWorkspaceSource } from "../foundation/types/afs";
+import { WorkspaceTable } from "../foundation/tables/workspace-table";
+import type { AFSWorkspaceSource, AFSWorkspaceView } from "../foundation/types/afs";
 
 export const Route = createFileRoute("/workspaces")({
   component: WorkspacesPage,
 });
 
+type WorkspaceFormState = {
+  name: string;
+  description: string;
+  cloudAccount: string;
+  databaseName: string;
+  region: string;
+  source: AFSWorkspaceSource;
+};
+
+type DialogMode = "create" | "edit" | null;
+
+function createInitialFormState(): WorkspaceFormState {
+  return {
+    name: "",
+    description: "",
+    cloudAccount: "Redis Cloud / Product",
+    databaseName: "agentfs-dev-us-east-1",
+    region: "us-east-1",
+    source: "blank",
+  };
+}
+
 function WorkspacesPage() {
   const navigate = useNavigate();
   const workspacesQuery = useWorkspaceSummaries();
   const createWorkspace = useCreateWorkspaceMutation();
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [cloudAccount, setCloudAccount] = useState("Redis Cloud / Product");
-  const [databaseName, setDatabaseName] = useState("agentfs-dev-us-east-1");
-  const [region, setRegion] = useState("us-east-1");
-  const [source, setSource] = useState<AFSWorkspaceSource>("blank");
+  const updateWorkspace = useUpdateWorkspaceMutation();
+  const deleteWorkspace = useDeleteWorkspaceMutation();
+
+  const [dialogMode, setDialogMode] = useState<DialogMode>(null);
+  const [editingWorkspaceId, setEditingWorkspaceId] = useState<string | null>(null);
+  const [previewWorkspaceId, setPreviewWorkspaceId] = useState<string | null>(null);
+  const [previewPath, setPreviewPath] = useState("/");
+  const [previewSelectedPath, setPreviewSelectedPath] = useState("");
+  const [form, setForm] = useState<WorkspaceFormState>(createInitialFormState);
+
+  const editingWorkspaceQuery = useWorkspace(
+    editingWorkspaceId ?? "",
+    dialogMode === "edit" && editingWorkspaceId != null,
+  );
+  const previewWorkspaceQuery = useWorkspace(
+    previewWorkspaceId ?? "",
+    previewWorkspaceId != null,
+  );
+  const previewTreeQuery = useWorkspaceTree(
+    {
+      workspaceId: previewWorkspaceId ?? "",
+      view: "head" as AFSWorkspaceView,
+      path: previewPath,
+      depth: 1,
+    },
+    previewWorkspaceId != null,
+  );
+  const previewFileQuery = useWorkspaceFileContent(
+    {
+      workspaceId: previewWorkspaceId ?? "",
+      view: "head" as AFSWorkspaceView,
+      path: previewSelectedPath,
+    },
+    previewWorkspaceId != null && previewSelectedPath !== "",
+  );
+
+  useEffect(() => {
+    const workspace = editingWorkspaceQuery.data;
+    if (workspace == null || dialogMode !== "edit") {
+      return;
+    }
+
+    setForm({
+      name: workspace.name,
+      description: workspace.description,
+      cloudAccount: workspace.cloudAccount,
+      databaseName: workspace.databaseName,
+      region: workspace.region,
+      source: workspace.source,
+    });
+  }, [dialogMode, editingWorkspaceQuery.data]);
+
+  useEffect(() => {
+    setPreviewPath("/");
+    setPreviewSelectedPath("");
+  }, [previewWorkspaceId]);
 
   if (workspacesQuery.isLoading) {
     return <Loader data-testid="loader--spinner" />;
   }
 
   const workspaces = workspacesQuery.data ?? [];
-  const healthy = workspaces.filter((workspace) => workspace.status === "healthy").length;
-  const dirty = workspaces.filter((workspace) => workspace.draftState === "dirty").length;
-  const imported = workspaces.filter((workspace) => workspace.source !== "blank").length;
-  const checkpoints = workspaces.reduce((sum, workspace) => sum + workspace.checkpointCount, 0);
+  const isDialogOpen = dialogMode != null;
+  const isEditing = dialogMode === "edit" && editingWorkspaceId != null;
+  const formBusy =
+    createWorkspace.isPending ||
+    updateWorkspace.isPending ||
+    (isEditing && editingWorkspaceQuery.isLoading);
+
+  function closeDialog() {
+    setDialogMode(null);
+    setEditingWorkspaceId(null);
+    setForm(createInitialFormState());
+  }
+
+  function openCreateDialog() {
+    setDialogMode("create");
+    setEditingWorkspaceId(null);
+    setForm(createInitialFormState());
+  }
+
+  function openEditDialog(workspaceId: string) {
+    setPreviewWorkspaceId(null);
+    setDialogMode("edit");
+    setEditingWorkspaceId(workspaceId);
+  }
+
+  function updateForm<TKey extends keyof WorkspaceFormState>(
+    key: TKey,
+    value: WorkspaceFormState[TKey],
+  ) {
+    setForm((current) => ({ ...current, [key]: value }));
+  }
+
+  function openWorkspace(workspaceId: string) {
+    void navigate({
+      to: "/workspaces/$workspaceId",
+      params: { workspaceId },
+    });
+  }
+
+  function openWorkspacePreview(workspaceId: string) {
+    setPreviewWorkspaceId(workspaceId);
+  }
+
+  function deleteSelectedWorkspace(workspaceId: string) {
+    const workspace = workspaces.find((item) => item.id === workspaceId);
+    const confirmed = window.confirm(
+      `Delete workspace "${workspace?.name ?? workspaceId}"? This removes its registry entry from the catalog.`,
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    deleteWorkspace.mutate(workspaceId, {
+      onSuccess: () => {
+        if (editingWorkspaceId === workspaceId) {
+          closeDialog();
+        }
+        if (previewWorkspaceId === workspaceId) {
+          setPreviewWorkspaceId(null);
+        }
+      },
+    });
+  }
+
+  const previewWorkspace = previewWorkspaceQuery.data;
+  const previewItems = previewTreeQuery.data?.items ?? [];
+  const previewFile = previewFileQuery.data;
 
   return (
     <PageStack>
-      <StatGrid>
-        <StatCard>
-          <div>
-            <StatLabel>Catalog Size</StatLabel>
-            <StatValue>{workspaces.length}</StatValue>
-          </div>
-          <StatDetail>Each row is one complete Redis-backed filesystem namespace.</StatDetail>
-        </StatCard>
-        <StatCard>
-          <div>
-            <StatLabel>Healthy</StatLabel>
-            <StatValue>{healthy}</StatValue>
-          </div>
-          <StatDetail>Healthy workspaces are ready to browse, edit, or checkpoint.</StatDetail>
-        </StatCard>
-        <StatCard>
-          <div>
-            <StatLabel>Dirty Drafts</StatLabel>
-            <StatValue>{dirty}</StatValue>
-          </div>
-          <StatDetail>Dirty working copies deserve fast access from the catalog.</StatDetail>
-        </StatCard>
-        <StatCard>
-          <div>
-            <StatLabel>Imported</StatLabel>
-            <StatValue>{imported}</StatValue>
-          </div>
-          <StatDetail>{checkpoints} checkpoints are already attached across imported and local workspaces.</StatDetail>
-        </StatCard>
-      </StatGrid>
+      <PageActionsRow>
+        <Button size="medium" onClick={openCreateDialog}>
+          Add workspace
+        </Button>
+      </PageActionsRow>
 
-      <SectionGrid>
-        <SectionCard $span={4}>
-          <SectionHeader>
-            <SectionTitle
-              eyebrow="Workspace Intake"
-              title="Create or import a workspace"
-              body="This intake surface should feel closer to provisioning a managed environment than filling out a generic form. Source choice, database mapping, and region belong together."
-            />
-          </SectionHeader>
+      <WorkspaceTable
+        rows={workspaces}
+        loading={workspacesQuery.isLoading}
+        error={workspacesQuery.isError}
+        deletingWorkspaceId={
+          deleteWorkspace.isPending ? deleteWorkspace.variables : null
+        }
+        onPreviewWorkspace={openWorkspacePreview}
+        onOpenWorkspace={openWorkspace}
+        onEditWorkspace={openEditDialog}
+        onDeleteWorkspace={deleteSelectedWorkspace}
+      />
 
-          <SourcePicker>
-            <SourceOption
-              $active={source === "blank"}
-              type="button"
-              onClick={() => setSource("blank")}
-            >
-              <SourceTitle>Blank workspace</SourceTitle>
-              <SourceBody>Start with an empty filesystem and build fresh state in Redis.</SourceBody>
-            </SourceOption>
-            <SourceOption
-              $active={source === "git-import"}
-              type="button"
-              onClick={() => setSource("git-import")}
-            >
-              <SourceTitle>Git import</SourceTitle>
-              <SourceBody>Seed a workspace from code or configuration that still needs browser-side edits.</SourceBody>
-            </SourceOption>
-            <SourceOption
-              $active={source === "cloud-import"}
-              type="button"
-              onClick={() => setSource("cloud-import")}
-            >
-              <SourceTitle>Redis Cloud import</SourceTitle>
-              <SourceBody>Pull an existing managed workspace into the control plane catalog.</SourceBody>
-            </SourceOption>
-          </SourcePicker>
-
-          <FormGrid
-            onSubmit={(event) => {
-              event.preventDefault();
-              if (name.trim() === "") {
-                return;
-              }
-
-              createWorkspace.mutate(
-                {
-                  name,
-                  description,
-                  cloudAccount,
-                  databaseName,
-                  region,
-                  source,
-                },
-                {
-                  onSuccess: (workspace) => {
-                    setName("");
-                    setDescription("");
-                    setDatabaseName("agentfs-dev-us-east-1");
+      {previewWorkspaceId != null ? (
+        <DetailPanelOverlay
+          onClick={(event) => {
+            if (event.target === event.currentTarget) {
+              setPreviewWorkspaceId(null);
+            }
+          }}
+        >
+          <DetailPanel>
+            <DialogHeader>
+              <SectionTitle
+                eyebrow="Workspace Details"
+                title={previewWorkspace?.name ?? previewWorkspaceId}
+                body="Browse the saved contents of this workspace here, or jump directly to its checkpoint history."
+              />
+              <InlineButtonRow>
+                <Button
+                  size="medium"
+                  onClick={() => {
                     void navigate({
                       to: "/workspaces/$workspaceId",
-                      params: { workspaceId: workspace.id },
+                      params: { workspaceId: previewWorkspaceId },
+                      search: { tab: "checkpoints" },
                     });
-                  },
-                },
-              );
-            }}
-          >
-            <TwoColumnFields>
-              <Field>
-                Workspace name
-                <TextInput
-                  value={name}
-                  onChange={(event) => setName(event.target.value)}
-                  placeholder="customer-portal"
-                />
-              </Field>
-              <Field>
-                Database name
-                <TextInput
-                  value={databaseName}
-                  onChange={(event) => setDatabaseName(event.target.value)}
-                  placeholder="agentfs-dev-us-east-1"
-                />
-              </Field>
-            </TwoColumnFields>
-            <Field>
-              Description
-              <TextArea
-                value={description}
-                onChange={(event) => setDescription(event.target.value)}
-                placeholder="What this workspace is for, which team owns it, and why it exists."
-              />
-            </Field>
-            <TwoColumnFields>
-              <Field>
-                Cloud account
-                <TextInput
-                  value={cloudAccount}
-                  onChange={(event) => setCloudAccount(event.target.value)}
-                />
-              </Field>
-              <Field>
-                Region
-                <TextInput
-                  value={region}
-                  onChange={(event) => setRegion(event.target.value)}
-                />
-              </Field>
-            </TwoColumnFields>
-            <Field>
-              Source
-              <Select
-                value={source}
-                onChange={(event) => setSource(event.target.value as AFSWorkspaceSource)}
-              >
-                <option value="blank">Blank workspace</option>
-                <option value="git-import">Git import</option>
-                <option value="cloud-import">Redis Cloud import</option>
-              </Select>
-            </Field>
-            <Button disabled={createWorkspace.isPending} size="medium" type="submit">
-              {createWorkspace.isPending ? "Creating..." : "Create workspace"}
-            </Button>
-          </FormGrid>
+                  }}
+                >
+                  Checkpoints
+                </Button>
+                <Button
+                  size="medium"
+                  variant="secondary-fill"
+                  onClick={() => setPreviewWorkspaceId(null)}
+                >
+                  Close
+                </Button>
+              </InlineButtonRow>
+            </DialogHeader>
 
-          <FormNote>
-            Opening a workspace immediately after creation keeps the catalog action-oriented: provision
-            here, inspect in the studio, then checkpoint once the draft settles.
-          </FormNote>
-        </SectionCard>
+            <DetailBrowserGrid>
+              <BrowserCard>
+                <CardHeader>
+                  <div>
+                    <Typography.Heading component="h3" size="S">
+                      File browser
+                    </Typography.Heading>
+                    <Typography.Body color="secondary" component="p">
+                      {previewPath}
+                    </Typography.Body>
+                  </div>
+                  <Button
+                    size="medium"
+                    variant="secondary-fill"
+                    disabled={previewPath === "/"}
+                    onClick={() => {
+                      setPreviewPath(parentPath(previewPath));
+                      setPreviewSelectedPath("");
+                    }}
+                  >
+                    Up
+                  </Button>
+                </CardHeader>
 
-        <SectionCard $span={8}>
-          <SectionHeader>
-            <SectionTitle
-              eyebrow="Fleet Catalog"
-              title="Workspace catalog"
-              body="The table should support triage as much as discovery: status, draft state, content size, and checkpoint depth all matter before you open the studio."
-            />
-          </SectionHeader>
+                {previewTreeQuery.isLoading ? <PanelNote>Loading directory contents...</PanelNote> : null}
+                {previewTreeQuery.isError ? <PanelNote>Unable to load this directory.</PanelNote> : null}
 
-          <WorkspaceTable
-            rows={workspaces}
-            loading={workspacesQuery.isLoading}
-            error={workspacesQuery.isError}
-            onOpenWorkspace={(workspaceId) =>
-              void navigate({
-                to: "/workspaces/$workspaceId",
-                params: { workspaceId },
-              })
+                <FileList style={{ marginTop: 14 }}>
+                  {previewItems.map((item) => (
+                    <FileButton
+                      key={item.path}
+                      $active={item.path === previewSelectedPath}
+                      onClick={() => {
+                        if (item.kind === "dir") {
+                          setPreviewPath(item.path);
+                          setPreviewSelectedPath("");
+                          return;
+                        }
+                        setPreviewSelectedPath(item.path);
+                      }}
+                    >
+                      <FileButtonHeader>
+                        <Typography.Body component="strong">{item.name}</Typography.Body>
+                        <FileKind>{item.kind}</FileKind>
+                      </FileButtonHeader>
+                      <Typography.Body color="secondary" component="p">
+                        {item.kind !== "dir" ? `${formatItemSize(item.size)} · ` : ""}
+                        {item.modifiedAt
+                          ? new Date(item.modifiedAt).toLocaleString()
+                          : "No modification timestamp"}
+                      </Typography.Body>
+                    </FileButton>
+                  ))}
+                  {!previewTreeQuery.isLoading && previewItems.length === 0 ? (
+                    <PanelNote>This directory is empty.</PanelNote>
+                  ) : null}
+                </FileList>
+              </BrowserCard>
+
+              <EditorPanel>
+                {previewSelectedPath === "" ? (
+                  <PanelNote>Select a file to inspect its contents.</PanelNote>
+                ) : previewFileQuery.isLoading ? (
+                  <PanelNote>Loading file content...</PanelNote>
+                ) : previewFile == null ? (
+                  <PanelNote>Select a file to inspect its contents.</PanelNote>
+                ) : previewFile.binary ? (
+                  <DetailStack>
+                    <CardHeader>
+                      <div>
+                        <Typography.Heading component="h3" size="S">
+                          {previewFile.path}
+                        </Typography.Heading>
+                        <Typography.Body color="secondary" component="p">
+                          Binary asset
+                        </Typography.Body>
+                      </div>
+                    </CardHeader>
+                    <Typography.Body color="secondary" component="p">
+                      This item looks binary, so the details panel is showing metadata instead of raw content.
+                    </Typography.Body>
+                  </DetailStack>
+                ) : (
+                  <DetailStack>
+                    <CardHeader>
+                      <div>
+                        <Typography.Heading component="h3" size="S">
+                          {previewFile.path}
+                        </Typography.Heading>
+                        <Typography.Body color="secondary" component="p">
+                          {previewFile.language}
+                        </Typography.Body>
+                      </div>
+                    </CardHeader>
+                    <EditorArea readOnly value={previewFile.content ?? previewFile.target ?? ""} />
+                  </DetailStack>
+                )}
+              </EditorPanel>
+            </DetailBrowserGrid>
+          </DetailPanel>
+        </DetailPanelOverlay>
+      ) : null}
+
+      {isDialogOpen ? (
+        <DialogOverlay
+          onClick={(event) => {
+            if (event.target === event.currentTarget) {
+              closeDialog();
             }
-          />
-        </SectionCard>
-      </SectionGrid>
+          }}
+        >
+          <DialogCard>
+            <DialogHeader>
+              <SectionTitle
+                eyebrow={isEditing ? "Edit Workspace" : "Add Workspace"}
+                title={isEditing ? "Update workspace details" : "Create a workspace"}
+                body={
+                  isEditing
+                    ? "Update the workspace metadata without leaving the registry."
+                    : "Create a workspace and choose how it should enter the registry."
+                }
+              />
+              <Button size="medium" variant="secondary-fill" onClick={closeDialog}>
+                Close
+              </Button>
+            </DialogHeader>
+
+            <SourcePicker>
+              <SourceOption
+                $active={form.source === "blank"}
+                disabled={isEditing}
+                type="button"
+                onClick={() => updateForm("source", "blank")}
+              >
+                <SourceTitle>Blank workspace</SourceTitle>
+                <SourceBody>Start from an empty filesystem and shape the workspace from scratch.</SourceBody>
+              </SourceOption>
+              <SourceOption
+                $active={form.source === "git-import"}
+                disabled={isEditing}
+                type="button"
+                onClick={() => updateForm("source", "git-import")}
+              >
+                <SourceTitle>Git import</SourceTitle>
+                <SourceBody>Bring in code or configuration that still needs browser-side edits.</SourceBody>
+              </SourceOption>
+              <SourceOption
+                $active={form.source === "cloud-import"}
+                disabled={isEditing}
+                type="button"
+                onClick={() => updateForm("source", "cloud-import")}
+              >
+                <SourceTitle>Redis Cloud import</SourceTitle>
+                <SourceBody>Register an existing managed workspace and operate on it from the studio.</SourceBody>
+              </SourceOption>
+            </SourcePicker>
+
+            <FormGrid
+              onSubmit={(event) => {
+                event.preventDefault();
+                if (form.name.trim() === "") {
+                  return;
+                }
+
+                if (editingWorkspaceId != null) {
+                  updateWorkspace.mutate(
+                    {
+                      workspaceId: editingWorkspaceId,
+                      description: form.description,
+                      cloudAccount: form.cloudAccount,
+                      databaseName: form.databaseName,
+                      region: form.region,
+                    },
+                    {
+                      onSuccess: () => {
+                        closeDialog();
+                      },
+                    },
+                  );
+                  return;
+                }
+
+                createWorkspace.mutate(
+                  {
+                    name: form.name,
+                    description: form.description,
+                    cloudAccount: form.cloudAccount,
+                    databaseName: form.databaseName,
+                    region: form.region,
+                    source: form.source,
+                  },
+                  {
+                    onSuccess: () => {
+                      closeDialog();
+                    },
+                  },
+                );
+              }}
+            >
+              <TwoColumnFields>
+                <Field>
+                  Workspace name
+                  <TextInput
+                    disabled={isEditing}
+                    value={form.name}
+                    onChange={(event) => updateForm("name", event.target.value)}
+                    placeholder="customer-portal"
+                  />
+                </Field>
+                <Field>
+                  Database hosting
+                  <TextInput
+                    value={form.databaseName}
+                    onChange={(event) => updateForm("databaseName", event.target.value)}
+                    placeholder="agentfs-dev-us-east-1"
+                  />
+                </Field>
+              </TwoColumnFields>
+
+              <Field>
+                Description
+                <TextArea
+                  value={form.description}
+                  onChange={(event) => updateForm("description", event.target.value)}
+                  placeholder="What this workspace is for, who owns it, and why it exists."
+                />
+              </Field>
+
+              <TwoColumnFields>
+                <Field>
+                  Cloud account
+                  <TextInput
+                    value={form.cloudAccount}
+                    onChange={(event) => updateForm("cloudAccount", event.target.value)}
+                  />
+                </Field>
+                <Field>
+                  Region
+                  <TextInput
+                    value={form.region}
+                    onChange={(event) => updateForm("region", event.target.value)}
+                  />
+                </Field>
+              </TwoColumnFields>
+
+              <Field>
+                Source
+                <Select
+                  disabled={isEditing}
+                  value={form.source}
+                  onChange={(event) => updateForm("source", event.target.value as AFSWorkspaceSource)}
+                >
+                  <option value="blank">Blank workspace</option>
+                  <option value="git-import">Git import</option>
+                  <option value="cloud-import">Redis Cloud import</option>
+                </Select>
+              </Field>
+
+              <DialogActions>
+                <Button disabled={formBusy} size="medium" type="submit">
+                  {isEditing
+                    ? updateWorkspace.isPending
+                      ? "Saving..."
+                      : "Save changes"
+                    : createWorkspace.isPending
+                      ? "Creating..."
+                      : "Create workspace"}
+                </Button>
+                <Button
+                  disabled={formBusy}
+                  size="medium"
+                  type="button"
+                  variant="secondary-fill"
+                  onClick={closeDialog}
+                >
+                  Cancel
+                </Button>
+              </DialogActions>
+            </FormGrid>
+          </DialogCard>
+        </DialogOverlay>
+      ) : null}
     </PageStack>
   );
 }
+
+const DialogOverlay = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(8, 6, 13, 0.36);
+`;
+
+const PageActionsRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+`;
+
+const DialogCard = styled.div`
+  width: min(760px, 100%);
+  max-height: min(88vh, 860px);
+  overflow: auto;
+  border: 1px solid var(--afs-line);
+  border-radius: 24px;
+  padding: 24px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(249, 251, 255, 0.94)),
+    var(--afs-panel);
+  box-shadow: var(--afs-shadow);
+`;
+
+const DialogHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  margin-bottom: 18px;
+
+  @media (max-width: 720px) {
+    flex-direction: column;
+  }
+`;
 
 const SourcePicker = styled.div`
   display: grid;
@@ -260,10 +595,16 @@ const SourceOption = styled.button<{ $active: boolean }>`
   transition:
     transform 160ms ease,
     border-color 160ms ease,
-    background 160ms ease;
+    background 160ms ease,
+    opacity 160ms ease;
 
-  &:hover {
+  &:hover:enabled {
     transform: translateY(-1px);
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.6;
   }
 `;
 
@@ -280,9 +621,94 @@ const SourceBody = styled.p`
   line-height: 1.6;
 `;
 
-const FormNote = styled.p`
-  margin: 18px 0 0;
+const DialogActions = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+`;
+
+const InlineButtonRow = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+`;
+
+const DetailPanelOverlay = styled(DialogOverlay)`
+  justify-content: flex-end;
+  padding: 24px;
+`;
+
+const DetailPanel = styled(DialogCard)`
+  width: min(920px, 100%);
+`;
+
+const DetailBrowserGrid = styled.div`
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(280px, 320px) minmax(0, 1fr);
+
+  @media (max-width: 1100px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const BrowserCard = styled.div`
+  border: 1px solid var(--afs-line);
+  border-radius: 24px;
+  padding: 18px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.84), rgba(243, 246, 251, 0.92)),
+    rgba(255, 255, 255, 0.8);
+`;
+
+const PanelNote = styled.p`
+  margin: 14px 0 0;
   color: var(--afs-muted);
   font-size: 14px;
-  line-height: 1.7;
+  line-height: 1.6;
 `;
+
+const FileButtonHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: center;
+`;
+
+const FileKind = styled.span`
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(8, 6, 13, 0.08);
+  color: var(--afs-muted);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+`;
+
+const DetailStack = styled.div`
+  display: grid;
+  gap: 16px;
+`;
+
+function parentPath(value: string) {
+  if (value === "/" || value === "") {
+    return "/";
+  }
+  const parts = value.split("/").filter(Boolean);
+  parts.pop();
+  return parts.length === 0 ? "/" : `/${parts.join("/")}`;
+}
+
+function formatItemSize(size: number) {
+  if (size === 0) {
+    return "0 KB";
+  }
+  return new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: 1,
+  }).format(size / 1024) + " KB";
+}


### PR DESCRIPTION
## Summary
- add a design document for bringing cloud-managed control plane patterns into AFS
- define `direct`, `self-hosted`, and `cloud` operating modes with standalone use preserved as a first-class path
- outline the required CLI backend split, HTTP API additions, auth model, profile/config changes, and rollout phases

## Testing
- Not run (not requested)