### PR TITLE
Expose atomic exclusive create across AFS surfaces

### DIFF
--- a/cmd/afs/afs_mcp.go
+++ b/cmd/afs/afs_mcp.go
@@ -242,6 +242,19 @@ func (s *afsMCPServer) Tools(_ context.Context) []mcpproto.Tool {
 			},
 		},
 		{
+			Name:        "file_create_exclusive",
+			Description: "Atomically create a file only if it does not already exist; fails if the path is already taken. Useful for distributed locking and coordination between agents. Creates parent directories as needed. Leaves the workspace dirty until checkpoint_create is called.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"workspace": map[string]string{"type": "string", "description": "Workspace name (defaults to current workspace)"},
+					"path":      map[string]string{"type": "string", "description": "Absolute file path"},
+					"content":   map[string]string{"type": "string", "description": "File contents to write on creation"},
+				},
+				"required": []string{"path", "content"},
+			},
+		},
+		{
 			Name:        "file_replace",
 			Description: "Replace text in a file and leave the workspace dirty until checkpoint_create is called",
 			InputSchema: map[string]any{
@@ -343,6 +356,8 @@ func (s *afsMCPServer) CallTool(ctx context.Context, name string, args map[strin
 		value, err = s.toolFileList(ctx, args)
 	case "file_write":
 		value, err = s.toolFileWrite(ctx, args)
+	case "file_create_exclusive":
+		value, err = s.toolFileCreateExclusive(ctx, args)
 	case "file_replace":
 		value, err = s.toolFileReplace(ctx, args)
 	case "file_insert":
@@ -671,6 +686,66 @@ func (s *afsMCPServer) toolFileWrite(ctx context.Context, args map[string]any) (
 			"bytes":     len(content),
 		}, nil
 	})
+}
+
+func (s *afsMCPServer) toolFileCreateExclusive(ctx context.Context, args map[string]any) (any, error) {
+	content, err := mcpRequiredText(args, "content", true)
+	if err != nil {
+		return nil, err
+	}
+	workspace, err := s.resolveWorkspaceArg(ctx, args, "workspace")
+	if err != nil {
+		return nil, err
+	}
+	rawPath, err := mcpRequiredString(args, "path")
+	if err != nil {
+		return nil, err
+	}
+	normalizedPath := normalizeAFSGrepPath(rawPath)
+
+	fsKey, _, _, err := s.store.ensureWorkspaceRoot(ctx, workspace)
+	if err != nil {
+		return nil, err
+	}
+	fsClient := client.New(s.store.rdb, fsKey)
+
+	// Check if path is already a directory.
+	if stat, statErr := fsClient.Stat(ctx, normalizedPath); statErr == nil && stat != nil {
+		if stat.Type == "dir" {
+			return nil, fmt.Errorf("path %q is a directory", normalizedPath)
+		}
+		return nil, fmt.Errorf("path %q already exists", normalizedPath)
+	}
+
+	if err := ensureWorkspaceParentDirs(ctx, fsClient, normalizedPath); err != nil {
+		return nil, err
+	}
+
+	// Atomic exclusive create via CreateFile (backed by HSETNX in Redis).
+	// When exclusive=true, CreateFile returns an error if the file already
+	// exists (via the HSETNX race), so we only need the error check.
+	_, _, err = fsClient.CreateFile(ctx, normalizedPath, 0o644, true)
+	if err != nil {
+		return nil, err
+	}
+
+	// Write the content into the newly created file.
+	if err := fsClient.Echo(ctx, normalizedPath, []byte(content)); err != nil {
+		return nil, err
+	}
+
+	dirty, err := s.refreshWorkspaceLiveState(ctx, workspace)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"operation": "create_exclusive",
+		"created":   true,
+		"workspace": workspace,
+		"path":      normalizedPath,
+		"bytes":     len(content),
+		"dirty":     dirty,
+	}, nil
 }
 
 func (s *afsMCPServer) toolFileReplace(ctx context.Context, args map[string]any) (any, error) {

--- a/cmd/afs/afs_mcp_test.go
+++ b/cmd/afs/afs_mcp_test.go
@@ -356,6 +356,237 @@ func frameForTest(body string) string {
 	return "Content-Length: " + strconv.Itoa(len(body)) + "\r\n\r\n" + body
 }
 
+func TestAFSMCPFileCreateExclusiveCreatesNewFile(t *testing.T) {
+	t.Helper()
+
+	server, closeFn := setupAFSMCPTestServer(t)
+	defer closeFn()
+
+	result := server.callTool(context.Background(), "file_create_exclusive", map[string]any{
+		"path":    "/tasks/001.claim",
+		"content": "agent-sre\n",
+	})
+	if result.IsError {
+		t.Fatalf("file_create_exclusive returned error result: %+v", result)
+	}
+
+	var payload map[string]any
+	if err := decodeStructuredContent(result.StructuredContent, &payload); err != nil {
+		t.Fatalf("decodeStructuredContent(create) returned error: %v", err)
+	}
+	if op, _ := payload["operation"].(string); op != "create_exclusive" {
+		t.Fatalf("operation = %#v, want %q", payload["operation"], "create_exclusive")
+	}
+	if created, _ := payload["created"].(bool); !created {
+		t.Fatalf("created = %#v, want true", payload["created"])
+	}
+	if dirty, _ := payload["dirty"].(bool); !dirty {
+		t.Fatalf("dirty = %#v, want true", payload["dirty"])
+	}
+
+	// Verify the file is readable with expected content.
+	readResult := server.callTool(context.Background(), "file_read", map[string]any{
+		"path": "/tasks/001.claim",
+	})
+	if readResult.IsError {
+		t.Fatalf("file_read returned error result: %+v", readResult)
+	}
+	var readPayload map[string]any
+	if err := decodeStructuredContent(readResult.StructuredContent, &readPayload); err != nil {
+		t.Fatalf("decodeStructuredContent(read) returned error: %v", err)
+	}
+	if got := readPayload["content"]; got != "agent-sre\n" {
+		t.Fatalf("file_read content = %#v, want written content", got)
+	}
+}
+
+func TestAFSMCPFileCreateExclusiveFailsWhenFileExists(t *testing.T) {
+	t.Helper()
+
+	server, closeFn := setupAFSMCPTestServer(t)
+	defer closeFn()
+
+	// Create the file first via normal write.
+	writeResult := server.callTool(context.Background(), "file_write", map[string]any{
+		"path":    "/tasks/001.claim",
+		"content": "agent-sre\n",
+	})
+	if writeResult.IsError {
+		t.Fatalf("file_write returned error result: %+v", writeResult)
+	}
+
+	// Attempt exclusive create — should fail.
+	result := server.callTool(context.Background(), "file_create_exclusive", map[string]any{
+		"path":    "/tasks/001.claim",
+		"content": "agent-deploy\n",
+	})
+	if !result.IsError {
+		t.Fatal("file_create_exclusive on existing file should return error, got success")
+	}
+}
+
+func TestAFSMCPFileCreateExclusiveDoubleCallSecondFails(t *testing.T) {
+	t.Helper()
+
+	server, closeFn := setupAFSMCPTestServer(t)
+	defer closeFn()
+
+	// First exclusive create succeeds.
+	first := server.callTool(context.Background(), "file_create_exclusive", map[string]any{
+		"path":    "/locks/deploy.lock",
+		"content": "agent-1\n",
+	})
+	if first.IsError {
+		t.Fatalf("first file_create_exclusive returned error: %+v", first)
+	}
+
+	// Second exclusive create to same path fails.
+	second := server.callTool(context.Background(), "file_create_exclusive", map[string]any{
+		"path":    "/locks/deploy.lock",
+		"content": "agent-2\n",
+	})
+	if !second.IsError {
+		t.Fatal("second file_create_exclusive should fail, got success")
+	}
+
+	// Original content should be preserved.
+	readResult := server.callTool(context.Background(), "file_read", map[string]any{
+		"path": "/locks/deploy.lock",
+	})
+	if readResult.IsError {
+		t.Fatalf("file_read returned error: %+v", readResult)
+	}
+	var readPayload map[string]any
+	if err := decodeStructuredContent(readResult.StructuredContent, &readPayload); err != nil {
+		t.Fatalf("decodeStructuredContent(read) returned error: %v", err)
+	}
+	if got := readPayload["content"]; got != "agent-1\n" {
+		t.Fatalf("content = %#v, want original agent-1 content", got)
+	}
+}
+
+func TestAFSMCPFileCreateExclusiveRequiresPath(t *testing.T) {
+	t.Helper()
+
+	server, closeFn := setupAFSMCPTestServer(t)
+	defer closeFn()
+
+	result := server.callTool(context.Background(), "file_create_exclusive", map[string]any{
+		"content": "data\n",
+	})
+	if !result.IsError {
+		t.Fatal("file_create_exclusive without path should return error, got success")
+	}
+}
+
+func TestAFSMCPFileCreateExclusiveRequiresContent(t *testing.T) {
+	t.Helper()
+
+	server, closeFn := setupAFSMCPTestServer(t)
+	defer closeFn()
+
+	result := server.callTool(context.Background(), "file_create_exclusive", map[string]any{
+		"path": "/tasks/empty.claim",
+	})
+	if !result.IsError {
+		t.Fatal("file_create_exclusive without content should return error, got success")
+	}
+}
+
+func TestAFSMCPFileCreateExclusiveAllowsEmptyContent(t *testing.T) {
+	t.Helper()
+
+	server, closeFn := setupAFSMCPTestServer(t)
+	defer closeFn()
+
+	result := server.callTool(context.Background(), "file_create_exclusive", map[string]any{
+		"path":    "/locks/empty.lock",
+		"content": "",
+	})
+	if result.IsError {
+		t.Fatalf("file_create_exclusive with empty content returned error: %+v", result)
+	}
+
+	readResult := server.callTool(context.Background(), "file_read", map[string]any{
+		"path": "/locks/empty.lock",
+	})
+	if readResult.IsError {
+		t.Fatalf("file_read returned error: %+v", readResult)
+	}
+
+	var readPayload map[string]any
+	if err := decodeStructuredContent(readResult.StructuredContent, &readPayload); err != nil {
+		t.Fatalf("decodeStructuredContent(read) returned error: %v", err)
+	}
+	if got := readPayload["content"]; got != "" {
+		t.Fatalf("content = %#v, want empty string", got)
+	}
+}
+
+func TestAFSMCPFileCreateExclusiveCreatesParentDirs(t *testing.T) {
+	t.Helper()
+
+	server, closeFn := setupAFSMCPTestServer(t)
+	defer closeFn()
+
+	result := server.callTool(context.Background(), "file_create_exclusive", map[string]any{
+		"path":    "/deep/nested/dir/file.lock",
+		"content": "locked\n",
+	})
+	if result.IsError {
+		t.Fatalf("file_create_exclusive with nested path returned error: %+v", result)
+	}
+
+	// Verify parent directory exists by listing it.
+	listResult := server.callTool(context.Background(), "file_list", map[string]any{
+		"path": "/deep/nested/dir",
+	})
+	if listResult.IsError {
+		t.Fatalf("file_list on parent dir returned error: %+v", listResult)
+	}
+}
+
+func TestAFSMCPFileCreateExclusiveOnDirectoryFails(t *testing.T) {
+	t.Helper()
+
+	server, closeFn := setupAFSMCPTestServer(t)
+	defer closeFn()
+
+	// Create a file to ensure parent dir exists.
+	writeResult := server.callTool(context.Background(), "file_write", map[string]any{
+		"path":    "/mydir/placeholder.txt",
+		"content": "x",
+	})
+	if writeResult.IsError {
+		t.Fatalf("file_write returned error: %+v", writeResult)
+	}
+
+	// Attempt exclusive create on the directory path.
+	result := server.callTool(context.Background(), "file_create_exclusive", map[string]any{
+		"path":    "/mydir",
+		"content": "should fail",
+	})
+	if !result.IsError {
+		t.Fatal("file_create_exclusive on a directory should return error, got success")
+	}
+}
+
+func TestAFSMCPFileCreateExclusiveNonexistentWorkspaceFails(t *testing.T) {
+	t.Helper()
+
+	server, closeFn := setupAFSMCPTestServer(t)
+	defer closeFn()
+
+	result := server.callTool(context.Background(), "file_create_exclusive", map[string]any{
+		"workspace": "no-such-workspace",
+		"path":      "/test.lock",
+		"content":   "data\n",
+	})
+	if !result.IsError {
+		t.Fatal("file_create_exclusive with nonexistent workspace should return error, got success")
+	}
+}
+
 func decodeStructuredContent(value any, target any) error {
 	body, err := json.Marshal(value)
 	if err != nil {

--- a/cmd/afs/main.go
+++ b/cmd/afs/main.go
@@ -76,6 +76,10 @@ func main() {
 		if err := cmdStatus(); err != nil {
 			fatal(err)
 		}
+	case "sync":
+		if err := cmdSync(args); err != nil {
+			fatal(err)
+		}
 	case "grep":
 		if err := cmdGrep(args); err != nil {
 			fatal(err)
@@ -154,6 +158,7 @@ func printUsage() {
 	fmt.Fprintf(w, "  %sup%s [flags]           %sStart sync/mount for the current workspace%s\n", bold, reset, dim, reset)
 	fmt.Fprintf(w, "  %sdown%s                 %sStop and unmount%s\n", bold, reset, dim, reset)
 	fmt.Fprintf(w, "  %sstatus%s               %sShow connection, workspace, and sync status%s\n", bold, reset, dim, reset)
+	fmt.Fprintf(w, "  %ssync%s                 %sExplicit operations for a running sync daemon%s\n", bold, reset, dim, reset)
 	// Data
 	fmt.Fprintf(w, "  %sworkspace%s            %sWorkspace ops — create, list, use, clone, fork, delete, import%s\n", bold, reset, dim, reset)
 	fmt.Fprintf(w, "  %sdatabase%s             %sDatabase ops — list, use%s\n", bold, reset, dim, reset)

--- a/cmd/afs/sync_control.go
+++ b/cmd/afs/sync_control.go
@@ -1,0 +1,308 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/redis/agent-filesystem/mount/client"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	syncControlVersion           = 1
+	syncControlDirName           = ".afs-sync"
+	syncControlRequestsDirName   = ".afs-sync/requests"
+	syncControlResultsDirName    = ".afs-sync/results"
+	syncControlOpCreateExclusive = "create-exclusive"
+	defaultSyncControlTimeout    = 10 * time.Second
+)
+
+type syncControlRequest struct {
+	Version   int    `json:"version"`
+	Operation string `json:"operation"`
+	Path      string `json:"path"`
+	Content   string `json:"content"`
+}
+
+type syncControlResult struct {
+	Version   int    `json:"version"`
+	Operation string `json:"operation"`
+	Path      string `json:"path"`
+	Success   bool   `json:"success"`
+	Bytes     int    `json:"bytes,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+func cmdSync(args []string) error {
+	if len(args) < 2 || isHelpArg(args[1]) {
+		fmt.Fprint(os.Stderr, syncUsageText(filepath.Base(os.Args[0])))
+		return nil
+	}
+
+	switch args[1] {
+	case "create-exclusive":
+		return cmdSyncCreateExclusive(args[2:])
+	default:
+		return fmt.Errorf("unknown sync subcommand %q\n\n%s", args[1], syncUsageText(filepath.Base(os.Args[0])))
+	}
+}
+
+func cmdSyncCreateExclusive(args []string) error {
+	if len(args) > 0 && isHelpArg(args[0]) {
+		fmt.Fprint(os.Stderr, syncCreateExclusiveUsageText(filepath.Base(os.Args[0])))
+		return nil
+	}
+
+	fs := flag.NewFlagSet("sync create-exclusive", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	var content optionalString
+	var contentFile string
+	var timeout time.Duration
+	fs.Var(&content, "content", "file content")
+	fs.StringVar(&contentFile, "content-file", "", "read content from file")
+	fs.DurationVar(&timeout, "timeout", defaultSyncControlTimeout, "how long to wait for the daemon result")
+	if err := fs.Parse(args); err != nil {
+		return fmt.Errorf("%s", syncCreateExclusiveUsageText(filepath.Base(os.Args[0])))
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("%s", syncCreateExclusiveUsageText(filepath.Base(os.Args[0])))
+	}
+	if content.set && strings.TrimSpace(contentFile) != "" {
+		return errors.New("--content and --content-file are mutually exclusive")
+	}
+
+	cfg, err := loadAFSConfig()
+	if err != nil {
+		return err
+	}
+	st, err := loadState()
+	if err != nil {
+		return fmt.Errorf("sync state unavailable: %w\nRun '%s up --mode sync' first", err, filepath.Base(os.Args[0]))
+	}
+	if strings.TrimSpace(st.Mode) != modeSync || st.SyncPID <= 0 || !processAlive(st.SyncPID) {
+		return fmt.Errorf("sync mode is not running\nRun '%s up --mode sync' first", filepath.Base(os.Args[0]))
+	}
+	if !runtimeStateMatchesConfig(cfg, st) {
+		return fmt.Errorf("sync daemon does not match the current config\nRun '%s up --mode sync' again", filepath.Base(os.Args[0]))
+	}
+
+	localRoot := strings.TrimSpace(st.LocalPath)
+	if localRoot == "" {
+		localRoot = strings.TrimSpace(cfg.LocalPath)
+	}
+	if localRoot == "" {
+		return errors.New("sync local path is not configured")
+	}
+
+	contentValue := content.value
+	if strings.TrimSpace(contentFile) != "" {
+		data, err := os.ReadFile(contentFile)
+		if err != nil {
+			return err
+		}
+		contentValue = string(data)
+	}
+
+	normalizedPath, err := normalizeSyncControlTarget(fs.Arg(0))
+	if err != nil {
+		return err
+	}
+
+	requestID, err := randomSuffix()
+	if err != nil {
+		return err
+	}
+	request := syncControlRequest{
+		Version:   syncControlVersion,
+		Operation: syncControlOpCreateExclusive,
+		Path:      normalizedPath,
+		Content:   contentValue,
+	}
+
+	if err := writeSyncControlJSON(syncControlRequestPath(localRoot, requestID), request, 0o600); err != nil {
+		return err
+	}
+
+	resultPath := syncControlResultPath(localRoot, requestID)
+	deadline := time.Now().Add(timeout)
+	for {
+		data, err := os.ReadFile(resultPath)
+		if err == nil {
+			_ = os.Remove(resultPath)
+			var result syncControlResult
+			if err := json.Unmarshal(data, &result); err != nil {
+				return fmt.Errorf("parse sync result: %w", err)
+			}
+			if !result.Success {
+				if strings.TrimSpace(result.Error) == "" {
+					return errors.New("sync create-exclusive failed")
+				}
+				return errors.New(result.Error)
+			}
+			printBox(markerSuccess+" "+clr(ansiBold, "sync create-exclusive"), []boxRow{
+				{Label: "workspace", Value: currentWorkspaceLabel(st.CurrentWorkspace)},
+				{Label: "path", Value: result.Path},
+				{Label: "bytes", Value: fmt.Sprintf("%d", result.Bytes)},
+			})
+			return nil
+		}
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for sync daemon result for %s", normalizedPath)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+func syncUsageText(bin string) string {
+	return brandHeaderString() + fmt.Sprintf(`Usage:
+  %s sync <subcommand>
+
+Explicit operations for a running sync daemon.
+
+Subcommands:
+  create-exclusive   Atomically create a file in the synced workspace exactly once
+`, bin)
+}
+
+func syncCreateExclusiveUsageText(bin string) string {
+	return brandHeaderString() + fmt.Sprintf(`Usage:
+  %s sync create-exclusive [--content <text> | --content-file <path>] [--timeout <duration>] <path>
+
+Ask the running sync daemon to atomically create <path> exactly once across
+all clients. The path must be absolute inside the workspace, for example:
+
+  %s sync create-exclusive /tasks/001.claim
+  %s sync create-exclusive --content "agent-a\n" /tasks/001.claim
+`, bin, bin, bin)
+}
+
+func syncControlRequestPath(root, requestID string) string {
+	return filepath.Join(root, syncControlDirName, "requests", requestID+".json")
+}
+
+func syncControlResultPath(root, requestID string) string {
+	return filepath.Join(root, syncControlDirName, "results", requestID+".json")
+}
+
+func isSyncControlPath(rel string) bool {
+	rel = strings.Trim(strings.TrimSpace(filepath.ToSlash(rel)), "/")
+	if rel == "" {
+		return false
+	}
+	return rel == syncControlDirName || strings.HasPrefix(rel, syncControlDirName+"/")
+}
+
+// Sync mode can observe path changes but not the original open flags, so
+// exclusive-create requests travel through a daemon-owned request/result side
+// channel under the local sync root.
+func syncControlRequestID(rel string) (string, bool) {
+	rel = strings.Trim(strings.TrimSpace(filepath.ToSlash(rel)), "/")
+	prefix := syncControlRequestsDirName + "/"
+	if !strings.HasPrefix(rel, prefix) || !strings.HasSuffix(rel, ".json") {
+		return "", false
+	}
+	rest := strings.TrimSuffix(strings.TrimPrefix(rel, prefix), ".json")
+	if rest == "" || strings.Contains(rest, "/") {
+		return "", false
+	}
+	return rest, true
+}
+
+func normalizeSyncControlTarget(raw string) (string, error) {
+	normalized := normalizeAFSGrepPath(raw)
+	if normalized == "/" {
+		return "", errors.New("target path must not be /")
+	}
+	if isSyncControlPath(strings.TrimPrefix(normalized, "/")) {
+		return "", fmt.Errorf("path %q is reserved for sync control", normalized)
+	}
+	return normalized, nil
+}
+
+func writeSyncControlJSON(path string, value any, mode uint32) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return writeAtomicFile(path, data, mode)
+}
+
+func writeAtomicFile(absPath string, data []byte, mode uint32) error {
+	if mode == 0 {
+		mode = 0o644
+	}
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+		return err
+	}
+	dir := filepath.Dir(absPath)
+	base := filepath.Base(absPath)
+	suffix, err := randomSuffix()
+	if err != nil {
+		return err
+	}
+	tmpName := filepath.Join(dir, "."+base+".afssync.tmp."+suffix)
+	f, err := os.OpenFile(tmpName, os.O_WRONLY|os.O_CREATE|os.O_EXCL|os.O_TRUNC, os.FileMode(mode&0o7777))
+	if err != nil {
+		return err
+	}
+	cleanup := func() {
+		_ = os.Remove(tmpName)
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		cleanup()
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		cleanup()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return err
+	}
+	if err := os.Rename(tmpName, absPath); err != nil {
+		cleanup()
+		return err
+	}
+	if err := os.Chmod(absPath, os.FileMode(mode&0o7777)); err != nil && !errors.Is(err, os.ErrNotExist) {
+	}
+	return nil
+}
+
+func ensureSyncRemoteParentDirs(ctx context.Context, fsClient client.Client, normalizedPath string) error {
+	trimmed := strings.Trim(normalizedPath, "/")
+	if trimmed == "" {
+		return nil
+	}
+	parts := strings.Split(trimmed, "/")
+	if len(parts) <= 1 {
+		return nil
+	}
+	current := ""
+	for _, part := range parts[:len(parts)-1] {
+		current += "/" + part
+		if stat, err := fsClient.Stat(ctx, current); err == nil && stat != nil {
+			continue
+		} else if err != nil && !errors.Is(err, redis.Nil) {
+			return err
+		}
+		if err := fsClient.Mkdir(ctx, current); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/afs/sync_downloader.go
+++ b/cmd/afs/sync_downloader.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -335,49 +334,7 @@ func (d *downloader) processChmod(ctx context.Context, op downloadOp) {
 // either the old or the new file but never a partial. The temp filename
 // embeds .afssync.tmp so the baseline ignore filter drops the watcher event.
 func (d *downloader) atomicWriteFile(absPath string, data []byte, mode uint32) error {
-	if mode == 0 {
-		mode = 0o644
-	}
-	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
-		return err
-	}
-	dir := filepath.Dir(absPath)
-	base := filepath.Base(absPath)
-	suffix, err := randomSuffix()
-	if err != nil {
-		return err
-	}
-	tmpName := filepath.Join(dir, "."+base+".afssync.tmp."+fmt.Sprintf("%d.%s", d.pid, suffix))
-	f, err := os.OpenFile(tmpName, os.O_WRONLY|os.O_CREATE|os.O_EXCL|os.O_TRUNC, fs.FileMode(mode&0o7777))
-	if err != nil {
-		return err
-	}
-	cleanup := func() {
-		_ = os.Remove(tmpName)
-	}
-	if _, err := f.Write(data); err != nil {
-		_ = f.Close()
-		cleanup()
-		return err
-	}
-	if err := f.Sync(); err != nil {
-		_ = f.Close()
-		cleanup()
-		return err
-	}
-	if err := f.Close(); err != nil {
-		cleanup()
-		return err
-	}
-	if err := os.Rename(tmpName, absPath); err != nil {
-		cleanup()
-		return err
-	}
-	// Re-apply mode in case the umask narrowed it.
-	if err := os.Chmod(absPath, fs.FileMode(mode&0o7777)); err != nil && !errors.Is(err, os.ErrNotExist) {
-		// Best effort.
-	}
-	return nil
+	return writeAtomicFile(absPath, data, mode)
 }
 
 func (d *downloader) send(r downloadResult) {
@@ -406,8 +363,8 @@ type echoSuppressor struct {
 }
 
 type echoExpectation struct {
-	kind   string // "file" | "symlink" | "dir" | "delete"
-	hash   string // sha256 hex for files; symlink target for symlinks
+	kind string // "file" | "symlink" | "dir" | "delete"
+	hash string // sha256 hex for files; symlink target for symlinks
 }
 
 func newEchoSuppressor() *echoSuppressor {
@@ -451,4 +408,3 @@ func (e *echoSuppressor) consume(rel string) (echoExpectation, bool) {
 	}
 	return exp, ok
 }
-

--- a/cmd/afs/sync_ignore.go
+++ b/cmd/afs/sync_ignore.go
@@ -75,6 +75,9 @@ func (s *syncIgnore) shouldIgnoreEntry(absPath string, entry fs.DirEntry) bool {
 		return false
 	}
 	rel = filepath.ToSlash(rel)
+	if isSyncControlPath(rel) {
+		return true
+	}
 	return s.shouldIgnore(rel, entry.IsDir())
 }
 

--- a/cmd/afs/sync_integration_test.go
+++ b/cmd/afs/sync_integration_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -233,6 +234,105 @@ func TestSyncEmptyFile(t *testing.T) {
 	})
 	if got := env.readRemoteFile(t, "empty.txt"); got != "" {
 		t.Fatalf("remote content = %q, want empty", got)
+	}
+}
+
+func TestSyncCreateExclusiveRequestCreatesRemoteAndLocal(t *testing.T) {
+	t.Helper()
+
+	env := newSyncTestEnv(t)
+	env.startDaemon(t)
+	defer env.stopDaemon()
+
+	requestID := "create-lock"
+	request := syncControlRequest{
+		Version:   syncControlVersion,
+		Operation: syncControlOpCreateExclusive,
+		Path:      "/locks/deploy.lock",
+		Content:   "agent-a\n",
+	}
+	if err := writeSyncControlJSON(syncControlRequestPath(env.localRoot, requestID), request, 0o600); err != nil {
+		t.Fatalf("writeSyncControlJSON(request) returned error: %v", err)
+	}
+
+	resultPath := syncControlResultPath(env.localRoot, requestID)
+	assertEventually(t, 3*time.Second, "sync control result", func() bool {
+		_, err := os.Stat(resultPath)
+		return err == nil
+	})
+
+	data, err := os.ReadFile(resultPath)
+	if err != nil {
+		t.Fatalf("ReadFile(result) returned error: %v", err)
+	}
+	var result syncControlResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("json.Unmarshal(result) returned error: %v", err)
+	}
+	if !result.Success {
+		t.Fatalf("result = %+v, want success", result)
+	}
+
+	assertEventually(t, 3*time.Second, "local lock file", func() bool {
+		return env.localExists("locks/deploy.lock")
+	})
+	if got := env.readLocalFile(t, "locks/deploy.lock"); got != "agent-a\n" {
+		t.Fatalf("local content = %q, want %q", got, "agent-a\n")
+	}
+	if got := env.readRemoteFile(t, "locks/deploy.lock"); got != "agent-a\n" {
+		t.Fatalf("remote content = %q, want %q", got, "agent-a\n")
+	}
+}
+
+func TestCmdSyncCreateExclusiveRoundTrip(t *testing.T) {
+	t.Helper()
+
+	env := newSyncTestEnv(t)
+	env.startDaemon(t)
+	defer env.stopDaemon()
+
+	oldCfgPathOverride := cfgPathOverride
+	cfgPathOverride = filepath.Join(t.TempDir(), "afs.config.json")
+	t.Cleanup(func() {
+		cfgPathOverride = oldCfgPathOverride
+	})
+
+	cfg := defaultConfig()
+	cfg.ProductMode = productModeLocal
+	cfg.Mode = modeSync
+	cfg.RedisAddr = env.mr.Addr()
+	cfg.RedisDB = 0
+	cfg.LocalPath = env.localRoot
+	cfg.CurrentWorkspace = env.workspace
+	if err := saveConfig(cfg); err != nil {
+		t.Fatalf("saveConfig() returned error: %v", err)
+	}
+
+	st := state{
+		ProductMode:      productModeLocal,
+		RedisAddr:        env.mr.Addr(),
+		RedisDB:          0,
+		CurrentWorkspace: env.workspace,
+		LocalPath:        env.localRoot,
+		Mode:             modeSync,
+		SyncPID:          os.Getpid(),
+	}
+	if err := saveState(st); err != nil {
+		t.Fatalf("saveState() returned error: %v", err)
+	}
+
+	if err := cmdSync([]string{"sync", "create-exclusive", "--content", "agent-b\n", "/tasks/002.claim"}); err != nil {
+		t.Fatalf("cmdSync(create-exclusive) returned error: %v", err)
+	}
+	assertEventually(t, 3*time.Second, "remote 002.claim", func() bool {
+		return env.remoteExists(t, "tasks/002.claim")
+	})
+	if got := env.readRemoteFile(t, "tasks/002.claim"); got != "agent-b\n" {
+		t.Fatalf("remote content = %q, want %q", got, "agent-b\n")
+	}
+
+	if err := cmdSync([]string{"sync", "create-exclusive", "/tasks/002.claim"}); err == nil {
+		t.Fatal("second cmdSync(create-exclusive) should fail, got success")
 	}
 }
 

--- a/cmd/afs/sync_reconciler.go
+++ b/cmd/afs/sync_reconciler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -26,20 +27,20 @@ type remoteEvent struct {
 // subscription events, upload results, and download results all funnel
 // through one goroutine so we never have to lock individual entries.
 type reconciler struct {
-	state    *stateWriter
-	root     string
+	state     *stateWriter
+	root      string
 	workspace string
-	store    *afsStore
-	echo     *echoSuppressor
-	conflict *conflictNamer
-	ignore   *syncIgnore
+	store     *afsStore
+	echo      *echoSuppressor
+	conflict  *conflictNamer
+	ignore    *syncIgnore
 
-	uploadCh    chan uploadOp
-	downloadCh  chan downloadOp
-	uploadResCh chan uploadResult
+	uploadCh      chan uploadOp
+	downloadCh    chan downloadOp
+	uploadResCh   chan uploadResult
 	downloadResCh chan downloadResult
-	localCh     <-chan LocalEvent
-	remoteCh    <-chan remoteEvent
+	localCh       <-chan LocalEvent
+	remoteCh      <-chan remoteEvent
 
 	fs           client.Client
 	maxFileBytes int64
@@ -159,6 +160,13 @@ func (r *reconciler) handleLocalEvent(ctx context.Context, ev LocalEvent) {
 	if ev.Path == "" {
 		return
 	}
+	if requestID, ok := syncControlRequestID(ev.Path); ok {
+		r.handleSyncControlRequest(ctx, ev.Path, requestID)
+		return
+	}
+	if isSyncControlPath(ev.Path) {
+		return
+	}
 	if r.ignore.shouldIgnore(ev.Path, false) {
 		return
 	}
@@ -202,6 +210,136 @@ func (r *reconciler) handleLocalEvent(ctx context.Context, ev LocalEvent) {
 		r.handleLocalFile(ev.Path, abs, info)
 	default:
 		// Sockets, fifos, devices: ignored.
+	}
+}
+
+func (r *reconciler) handleSyncControlRequest(ctx context.Context, rel, requestID string) {
+	abs := filepath.Join(r.root, filepath.FromSlash(rel))
+	data, err := os.ReadFile(abs)
+	if errors.Is(err, os.ErrNotExist) {
+		return
+	}
+	result := syncControlResult{
+		Version:   syncControlVersion,
+		Operation: syncControlOpCreateExclusive,
+		Success:   false,
+	}
+	if err != nil {
+		result.Error = fmt.Sprintf("read sync control request: %v", err)
+		r.writeSyncControlResult(requestID, result)
+		_ = os.Remove(abs)
+		return
+	}
+
+	var request syncControlRequest
+	if err := json.Unmarshal(data, &request); err != nil {
+		result.Error = fmt.Sprintf("parse sync control request: %v", err)
+		r.writeSyncControlResult(requestID, result)
+		_ = os.Remove(abs)
+		return
+	}
+
+	result = r.executeSyncControlRequest(ctx, request)
+	r.writeSyncControlResult(requestID, result)
+	_ = os.Remove(abs)
+}
+
+func (r *reconciler) executeSyncControlRequest(ctx context.Context, request syncControlRequest) syncControlResult {
+	result := syncControlResult{
+		Version:   syncControlVersion,
+		Operation: request.Operation,
+		Path:      request.Path,
+	}
+	if request.Version != 0 && request.Version != syncControlVersion {
+		result.Error = fmt.Sprintf("unsupported sync control version %d", request.Version)
+		return result
+	}
+	switch request.Operation {
+	case syncControlOpCreateExclusive:
+		return r.executeSyncCreateExclusive(ctx, request)
+	default:
+		result.Error = fmt.Sprintf("unsupported sync control operation %q", request.Operation)
+		return result
+	}
+}
+
+func (r *reconciler) executeSyncCreateExclusive(ctx context.Context, request syncControlRequest) syncControlResult {
+	result := syncControlResult{
+		Version:   syncControlVersion,
+		Operation: syncControlOpCreateExclusive,
+		Path:      request.Path,
+	}
+	if r.readonly {
+		result.Error = "sync daemon is read-only"
+		return result
+	}
+
+	normalizedPath, err := normalizeSyncControlTarget(request.Path)
+	if err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	result.Path = normalizedPath
+	rel := strings.TrimPrefix(normalizedPath, "/")
+	localAbs := filepath.Join(r.root, filepath.FromSlash(rel))
+
+	if _, err := os.Lstat(localAbs); err == nil {
+		result.Error = fmt.Sprintf("path %q already exists locally", normalizedPath)
+		return result
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		result.Error = fmt.Sprintf("stat local path %q: %v", normalizedPath, err)
+		return result
+	}
+
+	if err := ensureSyncRemoteParentDirs(ctx, r.fs, normalizedPath); err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	if _, _, err := r.fs.CreateFile(ctx, normalizedPath, 0o644, true); err != nil {
+		result.Error = err.Error()
+		return result
+	}
+	if err := r.fs.Echo(ctx, normalizedPath, []byte(request.Content)); err != nil {
+		result.Error = fmt.Sprintf("write remote path %q: %v", normalizedPath, err)
+		r.requestFullSweep()
+		return result
+	}
+	if err := writeAtomicFile(localAbs, []byte(request.Content), 0o644); err != nil {
+		result.Error = fmt.Sprintf("materialize local path %q: %v", normalizedPath, err)
+		r.requestFullSweep()
+		return result
+	}
+
+	hash := sha256Hex([]byte(request.Content))
+	r.echo.markFile(rel, hash)
+	localMtimeMs := time.Now().UTC().UnixMilli()
+	if info, err := os.Stat(localAbs); err == nil {
+		localMtimeMs = info.ModTime().UnixMilli()
+	}
+
+	r.state.mu.Lock()
+	r.state.state.Entries[rel] = SyncEntry{
+		Type:          "file",
+		Mode:          0o644,
+		Size:          int64(len(request.Content)),
+		LocalHash:     hash,
+		RemoteHash:    hash,
+		LocalMtimeMs:  localMtimeMs,
+		RemoteMtimeMs: localMtimeMs,
+		LastSyncedAt:  time.Now().UTC(),
+		Version:       r.state.nextVersion(),
+	}
+	r.state.dirty = true
+	r.state.mu.Unlock()
+
+	result.Success = true
+	result.Bytes = len(request.Content)
+	return result
+}
+
+func (r *reconciler) writeSyncControlResult(requestID string, result syncControlResult) {
+	if err := writeSyncControlJSON(syncControlResultPath(r.root, requestID), result, 0o600); err != nil {
+		fmt.Fprintf(os.Stderr, "afs sync: write control result %s: %v\n", requestID, err)
 	}
 }
 
@@ -555,15 +693,15 @@ func (r *reconciler) handleUploadResult(ctx context.Context, res uploadResult) {
 			size = res.Op.FileSize
 		}
 		entry := SyncEntry{
-			Type:          "file",
-			Mode:          res.Op.Mode,
-			Size:          size,
-			LocalHash:     res.Op.LocalHash,
-			RemoteHash:    res.Op.LocalHash,
-			LastSyncedAt:  now,
-			ChunkSize:     res.Op.ChunkSize,
-			ChunkHashes:   res.Op.ChunkHashes,
-			Version:       r.state.nextVersion(),
+			Type:         "file",
+			Mode:         res.Op.Mode,
+			Size:         size,
+			LocalHash:    res.Op.LocalHash,
+			RemoteHash:   res.Op.LocalHash,
+			LastSyncedAt: now,
+			ChunkSize:    res.Op.ChunkSize,
+			ChunkHashes:  res.Op.ChunkHashes,
+			Version:      r.state.nextVersion(),
 		}
 		if res.RemoteStat != nil {
 			entry.RemoteMtimeMs = res.RemoteStat.Mtime

--- a/internal/controlplane/mcp_hosted.go
+++ b/internal/controlplane/mcp_hosted.go
@@ -213,6 +213,18 @@ func (p *hostedMCPProvider) Tools(context.Context) []mcpproto.Tool {
 			},
 		},
 		{
+			Name:        "file_create_exclusive",
+			Description: "Atomically create a file only if it does not already exist; fails if the path is already taken. Useful for distributed locking and coordination between agents. Creates parent directories as needed.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"path":    map[string]string{"type": "string", "description": "Absolute file path"},
+					"content": map[string]string{"type": "string", "description": "File contents to write on creation"},
+				},
+				"required": []string{"path", "content"},
+			},
+		},
+		{
 			Name:        "file_replace",
 			Description: "Replace text in a file",
 			InputSchema: map[string]any{
@@ -317,6 +329,11 @@ func (p *hostedMCPProvider) CallTool(ctx context.Context, name string, args map[
 		err = p.ensureWritable()
 		if err == nil {
 			value, err = p.toolFileWrite(ctx, args)
+		}
+	case "file_create_exclusive":
+		err = p.ensureWritable()
+		if err == nil {
+			value, err = p.toolFileCreateExclusive(ctx, args)
 		}
 	case "file_replace":
 		err = p.ensureWritable()
@@ -431,6 +448,51 @@ func (p *hostedMCPProvider) toolFileWrite(ctx context.Context, args map[string]a
 		}
 		return map[string]any{"kind": stat.Type, "created": false, "bytes": len(content)}, nil
 	})
+}
+
+func (p *hostedMCPProvider) toolFileCreateExclusive(ctx context.Context, args map[string]any) (any, error) {
+	content, err := mcpRequiredText(args, "content", true)
+	if err != nil {
+		return nil, err
+	}
+	rawPath, err := mcpRequiredString(args, "path")
+	if err != nil {
+		return nil, err
+	}
+	normalizedPath := normalizeAFSGrepPath(rawPath)
+	fsClient, err := p.fsClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if stat, statErr := fsClient.Stat(ctx, normalizedPath); statErr == nil && stat != nil {
+		if stat.Type == "dir" {
+			return nil, fmt.Errorf("path %q is a directory", normalizedPath)
+		}
+		return nil, fmt.Errorf("path %q already exists", normalizedPath)
+	} else if statErr != nil && !errors.Is(statErr, redis.Nil) {
+		return nil, statErr
+	}
+
+	if err := ensureHostedWorkspaceParentDirs(ctx, fsClient, normalizedPath); err != nil {
+		return nil, err
+	}
+
+	_, _, err = fsClient.CreateFile(ctx, normalizedPath, 0o644, true)
+	if err != nil {
+		return nil, err
+	}
+	if err := fsClient.Echo(ctx, normalizedPath, []byte(content)); err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		"workspace": p.workspace,
+		"path":      normalizedPath,
+		"operation": "create_exclusive",
+		"created":   true,
+		"bytes":     len(content),
+	}, nil
 }
 
 func (p *hostedMCPProvider) toolFileReplace(ctx context.Context, args map[string]any) (any, error) {
@@ -570,6 +632,30 @@ func (p *hostedMCPProvider) mutateWorkspaceFile(ctx context.Context, args map[st
 	payload["workspace"] = p.workspace
 	payload["path"] = normalizedPath
 	return payload, nil
+}
+
+func ensureHostedWorkspaceParentDirs(ctx context.Context, fsClient afsclient.Client, normalizedPath string) error {
+	trimmed := strings.Trim(normalizedPath, "/")
+	if trimmed == "" {
+		return nil
+	}
+	parts := strings.Split(trimmed, "/")
+	if len(parts) <= 1 {
+		return nil
+	}
+	current := ""
+	for _, part := range parts[:len(parts)-1] {
+		current += "/" + part
+		if stat, err := fsClient.Stat(ctx, current); err == nil && stat != nil {
+			continue
+		} else if err != nil && !errors.Is(err, redis.Nil) {
+			return err
+		}
+		if err := fsClient.Mkdir(ctx, current); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func mcpErrorResult(err error) mcpproto.ToolResult {

--- a/internal/controlplane/mcp_hosted_test.go
+++ b/internal/controlplane/mcp_hosted_test.go
@@ -1,0 +1,87 @@
+package controlplane
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+func TestHostedMCPFileCreateExclusiveCreatesFile(t *testing.T) {
+	t.Helper()
+
+	manager, databaseID := newTestManager(t)
+	provider := &hostedMCPProvider{
+		manager:    manager,
+		databaseID: databaseID,
+		workspace:  "repo",
+	}
+
+	result := provider.CallTool(context.Background(), "file_create_exclusive", map[string]any{
+		"path":    "/locks/deploy.lock",
+		"content": "agent-1\n",
+	})
+	if result.IsError {
+		t.Fatalf("file_create_exclusive returned error result: %+v", result)
+	}
+
+	var payload map[string]any
+	if err := decodeHostedStructuredContent(result.StructuredContent, &payload); err != nil {
+		t.Fatalf("decodeHostedStructuredContent(create) returned error: %v", err)
+	}
+	if op, _ := payload["operation"].(string); op != "create_exclusive" {
+		t.Fatalf("operation = %#v, want %q", payload["operation"], "create_exclusive")
+	}
+	if created, _ := payload["created"].(bool); !created {
+		t.Fatalf("created = %#v, want true", payload["created"])
+	}
+
+	readResult := provider.CallTool(context.Background(), "file_read", map[string]any{
+		"path": "/locks/deploy.lock",
+	})
+	if readResult.IsError {
+		t.Fatalf("file_read returned error result: %+v", readResult)
+	}
+
+	var readPayload map[string]any
+	if err := decodeHostedStructuredContent(readResult.StructuredContent, &readPayload); err != nil {
+		t.Fatalf("decodeHostedStructuredContent(read) returned error: %v", err)
+	}
+	if got := readPayload["content"]; got != "agent-1\n" {
+		t.Fatalf("file_read content = %#v, want written content", got)
+	}
+}
+
+func TestHostedMCPFileCreateExclusiveFailsWhenFileExists(t *testing.T) {
+	t.Helper()
+
+	manager, databaseID := newTestManager(t)
+	provider := &hostedMCPProvider{
+		manager:    manager,
+		databaseID: databaseID,
+		workspace:  "repo",
+	}
+
+	first := provider.CallTool(context.Background(), "file_create_exclusive", map[string]any{
+		"path":    "/locks/deploy.lock",
+		"content": "agent-1\n",
+	})
+	if first.IsError {
+		t.Fatalf("first file_create_exclusive returned error result: %+v", first)
+	}
+
+	second := provider.CallTool(context.Background(), "file_create_exclusive", map[string]any{
+		"path":    "/locks/deploy.lock",
+		"content": "agent-2\n",
+	})
+	if !second.IsError {
+		t.Fatal("second file_create_exclusive should fail, got success")
+	}
+}
+
+func decodeHostedStructuredContent(value any, target any) error {
+	body, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(body, target)
+}


### PR DESCRIPTION
## Summary

This branch adds explicit atomic exclusive-create support across AFS surfaces so higher-level agent protocols can safely implement file-based claim/lock patterns.

The underlying Redis-backed filesystem already had a real distributed atomic create primitive (`CreateFile(..., exclusive=true)` backed by `HSETNX`). The gap was interface exposure: mount mode could already express this through normal filesystem semantics, but MCP and sync mode could not.

This change closes that gap by:
- adding `file_create_exclusive` to the CLI MCP server
- adding `file_create_exclusive` to the hosted MCP provider
- allowing empty-content exclusive creates for claim/lock files
- adding `afs sync create-exclusive` as an explicit sync-mode operation
- adding tests for CLI MCP, hosted MCP, and sync-mode behavior

## Why

File-based distributed lock / claim protocols require one filesystem-level guarantee: atomic “create this path iff it does not already exist.”

Without that guarantee, a protocol built on lock files is unsafe because two agents can race:
1. both observe the path as absent
2. both create the file
3. both believe they acquired the lock

AFS already had the correct atomic primitive in the Redis-backed client layer, so the goal of this branch is not to invent lock semantics. It is to expose the existing primitive consistently enough that agent protocols can rely on it.

This is intentionally scoped to filesystem support only:
- exactly one claimant can win
- losers get a definite failure
- higher-level lock concerns such as owner identity, leases, stale lock cleanup, and unlock rules remain above the filesystem layer

## What Changed

### MCP
Added `file_create_exclusive` to both MCP entrypoints:
- CLI MCP server
- hosted MCP provider

This gives MCP clients a direct, explicit atomic-create operation instead of forcing them through `file_write`, which is fundamentally overwrite-oriented.

### Sync mode
Added `afs sync create-exclusive` as an explicit operation handled by the running sync daemon.

This is implemented as a daemon-mediated control path rather than ordinary synced file creation. The daemon:
- receives an explicit create-exclusive request
- performs the remote exclusive create with `CreateFile(..., true)`
- writes content if creation succeeds
- materializes the result into the local sync folder
- returns success/failure to the caller

### Tests
Added coverage for:
- CLI MCP exclusive create behavior
- hosted MCP exclusive create behavior
- empty-content exclusive creates
- sync request/result flow
- sync CLI round-trip behavior

## Why sync mode is explicit

The main design choice in this branch is the sync-mode interface.

Mount mode can preserve `O_CREAT|O_EXCL` transparently because AFS owns the filesystem call path and can observe the create flags directly.

Sync mode cannot do that reliably. The sync daemon sees filesystem changes after they happen via watcher events. At that point it has paths and create/write/rename signals, but not the original open flags. That means ordinary local file creation in sync mode does not tell us whether the caller intended:
- normal file creation, or
- atomic create-if-absent

We considered whether sync mode could infer this automatically and rejected that approach.

## Tradeoffs

### Chosen approach
Use an explicit sync-only operation:
- `afs sync create-exclusive <path>`

Pros:
- correct
- explicit
- portable
- preserves existing sync behavior for ordinary files
- does not rely on platform-specific kernel instrumentation

Cons:
- interface is not identical to mount mode
- lock/claim creation in sync mode is a special command, not transparent ordinary file creation

### Rejected alternatives

#### 1. Infer exclusivity from watcher events
Rejected because watcher events do not preserve `O_EXCL` intent. This would be heuristic and incorrect.

#### 2. Use platform-specific OS/kernel tracing
Rejected because it is not a clean cross-platform product path and would make sync semantics depend on OS-specific low-level hooks.

#### 3. Introduce hidden filename conventions
Rejected because it overloads normal file naming with special semantics and is less explicit than a dedicated operation.

## Resulting surface model

After this branch:
- mount mode: use normal filesystem exclusive-create semantics
- MCP: use `file_create_exclusive`
- sync mode: use `afs sync create-exclusive`

This is not perfectly uniform at the syntax level, but it is uniform at the semantic level: every supported surface now has an explicit, correct way to perform atomic create-if-absent.

## Testing

Validated with:
- `go test ./cmd/afs ./internal/controlplane`
