### PR TITLE
Restore workspace-first change detail routes

### DIFF
--- a/internal/controlplane/database_manager.go
+++ b/internal/controlplane/database_manager.go
@@ -1128,7 +1128,25 @@ func (m *DatabaseManager) ListChangelog(ctx context.Context, databaseID, workspa
 	if err != nil {
 		return ChangelogListResponse{}, err
 	}
-	return service.ListChangelog(ctx, route.WorkspaceID, req)
+	response, err := service.ListChangelog(ctx, route.WorkspaceID, req)
+	if err != nil {
+		return ChangelogListResponse{}, err
+	}
+	m.attachDatabaseToChangelog(&response, route.DatabaseID)
+	return response, nil
+}
+
+func (m *DatabaseManager) ListResolvedChangelog(ctx context.Context, workspace string, req ChangelogListRequest) (ChangelogListResponse, error) {
+	service, _, route, err := m.resolveWorkspace(ctx, workspace)
+	if err != nil {
+		return ChangelogListResponse{}, err
+	}
+	response, err := service.ListChangelog(ctx, route.WorkspaceID, req)
+	if err != nil {
+		return ChangelogListResponse{}, err
+	}
+	m.attachDatabaseToChangelog(&response, route.DatabaseID)
+	return response, nil
 }
 
 // GetSessionChangelogSummary returns the per-session rollup (op counts, delta bytes).
@@ -1140,9 +1158,25 @@ func (m *DatabaseManager) GetSessionChangelogSummary(ctx context.Context, databa
 	return service.GetSessionChangelogSummary(ctx, route.WorkspaceID, sessionID)
 }
 
+func (m *DatabaseManager) GetResolvedSessionChangelogSummary(ctx context.Context, workspace, sessionID string) (SessionChangelogSummary, error) {
+	service, _, route, err := m.resolveWorkspace(ctx, workspace)
+	if err != nil {
+		return SessionChangelogSummary{}, err
+	}
+	return service.GetSessionChangelogSummary(ctx, route.WorkspaceID, sessionID)
+}
+
 // GetPathLastWriter returns the last-writer metadata for a single path.
 func (m *DatabaseManager) GetPathLastWriter(ctx context.Context, databaseID, workspace, path string) (PathLastWriter, error) {
 	service, _, route, err := m.resolveScopedWorkspace(ctx, databaseID, workspace)
+	if err != nil {
+		return PathLastWriter{}, err
+	}
+	return service.GetPathLastWriter(ctx, route.WorkspaceID, path)
+}
+
+func (m *DatabaseManager) GetResolvedPathLastWriter(ctx context.Context, workspace, path string) (PathLastWriter, error) {
+	service, _, route, err := m.resolveWorkspace(ctx, workspace)
 	if err != nil {
 		return PathLastWriter{}, err
 	}

--- a/internal/controlplane/http.go
+++ b/internal/controlplane/http.go
@@ -1931,6 +1931,64 @@ func handleResolvedWorkspaceRoute(
 			return
 		}
 		writeJSON(w, http.StatusOK, response)
+	case strings.HasSuffix(workspacePath, "/changes"):
+		workspace := strings.TrimSuffix(workspacePath, "/changes")
+		if r.Method != http.MethodGet {
+			writeError(w, fmt.Errorf("%s not allowed", r.Method))
+			return
+		}
+		limit, err := queryInt(r, "limit", 100)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		req := ChangelogListRequest{
+			SessionID: strings.TrimSpace(r.URL.Query().Get("session_id")),
+			Path:      strings.TrimSpace(r.URL.Query().Get("path")),
+			Since:     strings.TrimSpace(r.URL.Query().Get("since")),
+			Until:     strings.TrimSpace(r.URL.Query().Get("until")),
+			Limit:     limit,
+			Reverse:   strings.EqualFold(r.URL.Query().Get("direction"), "desc"),
+		}
+		response, err := manager.ListResolvedChangelog(r.Context(), workspace, req)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, response)
+	case strings.Contains(workspacePath, "/sessions/") && strings.HasSuffix(workspacePath, "/summary"):
+		parts := strings.Split(strings.Trim(workspacePath, "/"), "/")
+		if len(parts) != 4 || parts[1] != "sessions" || parts[3] != "summary" {
+			writeError(w, os.ErrNotExist)
+			return
+		}
+		if r.Method != http.MethodGet {
+			writeError(w, fmt.Errorf("%s not allowed", r.Method))
+			return
+		}
+		response, err := manager.GetResolvedSessionChangelogSummary(r.Context(), parts[0], parts[2])
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, response)
+	case strings.HasSuffix(workspacePath, "/path-last"):
+		workspace := strings.TrimSuffix(workspacePath, "/path-last")
+		if r.Method != http.MethodGet {
+			writeError(w, fmt.Errorf("%s not allowed", r.Method))
+			return
+		}
+		path := strings.TrimSpace(r.URL.Query().Get("path"))
+		if path == "" {
+			writeError(w, fmt.Errorf("path query parameter is required"))
+			return
+		}
+		response, err := manager.GetResolvedPathLastWriter(r.Context(), workspace, path)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, response)
 	case strings.HasSuffix(workspacePath, "/mcp-tokens"):
 		workspace := strings.TrimSuffix(workspacePath, "/mcp-tokens")
 		switch r.Method {

--- a/internal/controlplane/http_test.go
+++ b/internal/controlplane/http_test.go
@@ -714,6 +714,108 @@ func TestHTTPFileHistoryAndVersionContentRoutes(t *testing.T) {
 	}
 }
 
+func TestHTTPWorkspaceFirstChangeRoutesResolveOpaqueWorkspaceID(t *testing.T) {
+	t.Helper()
+
+	ctx := context.Background()
+	manager, databaseID := newTestManager(t)
+	detail, err := manager.GetWorkspace(ctx, databaseID, "repo")
+	if err != nil {
+		t.Fatalf("GetWorkspace() returned error: %v", err)
+	}
+	if !strings.HasPrefix(detail.ID, "ws_") {
+		t.Fatalf("detail.ID = %q, want opaque workspace id", detail.ID)
+	}
+
+	service, _, err := manager.serviceFor(ctx, databaseID)
+	if err != nil {
+		t.Fatalf("serviceFor() returned error: %v", err)
+	}
+
+	const (
+		sessionID = "sess-workspace-first"
+		path      = "/notes/opaque-route.txt"
+	)
+	WriteChangeEntries(ctx, service.store.rdb, detail.ID, []ChangeEntry{{
+		SessionID:   sessionID,
+		AgentID:     "agt-http",
+		Op:          ChangeOpPut,
+		Path:        path,
+		DeltaBytes:  17,
+		ContentHash: "blob-opaque",
+		Source:      ChangeSourceMCP,
+	}})
+
+	server := httptest.NewServer(NewHandler(manager, "*"))
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/v1/workspaces/" + detail.ID + "/changes?limit=10")
+	if err != nil {
+		t.Fatalf("GET workspace-first changes returned error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET workspace-first changes status = %d, want %d, body=%s", resp.StatusCode, http.StatusOK, body)
+	}
+
+	var changes ChangelogListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&changes); err != nil {
+		t.Fatalf("Decode(workspace-first changes) returned error: %v", err)
+	}
+	if len(changes.Entries) != 1 {
+		t.Fatalf("len(workspace-first changes.entries) = %d, want 1", len(changes.Entries))
+	}
+	if changes.Entries[0].Path != path || changes.Entries[0].SessionID != sessionID {
+		t.Fatalf("workspace-first change entry = %#v, want path/session %q/%q", changes.Entries[0], path, sessionID)
+	}
+	if changes.Entries[0].DatabaseID != databaseID {
+		t.Fatalf("workspace-first change database_id = %q, want %q", changes.Entries[0].DatabaseID, databaseID)
+	}
+
+	resp, err = http.Get(server.URL + "/v1/workspaces/" + detail.ID + "/path-last?path=" + url.QueryEscape(path))
+	if err != nil {
+		t.Fatalf("GET workspace-first path-last returned error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET workspace-first path-last status = %d, want %d, body=%s", resp.StatusCode, http.StatusOK, body)
+	}
+
+	var last PathLastWriter
+	if err := json.NewDecoder(resp.Body).Decode(&last); err != nil {
+		t.Fatalf("Decode(workspace-first path-last) returned error: %v", err)
+	}
+	if last.Path != path || last.SessionID != sessionID || last.Op != ChangeOpPut || last.ContentHash != "blob-opaque" {
+		t.Fatalf("workspace-first path-last = %#v, want path/session/op/hash %q/%q/%q/%q", last, path, sessionID, ChangeOpPut, "blob-opaque")
+	}
+
+	resp, err = http.Get(server.URL + "/v1/workspaces/" + detail.ID + "/sessions/" + sessionID + "/summary")
+	if err != nil {
+		t.Fatalf("GET workspace-first session summary returned error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET workspace-first session summary status = %d, want %d, body=%s", resp.StatusCode, http.StatusOK, body)
+	}
+
+	var summary SessionChangelogSummary
+	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
+		t.Fatalf("Decode(workspace-first session summary) returned error: %v", err)
+	}
+	if summary.SessionID != sessionID {
+		t.Fatalf("workspace-first session summary session_id = %q, want %q", summary.SessionID, sessionID)
+	}
+	if summary.OpCounts[ChangeOpPut] != 1 {
+		t.Fatalf("workspace-first session summary put count = %d, want 1", summary.OpCounts[ChangeOpPut])
+	}
+	if summary.DeltaBytes != 17 {
+		t.Fatalf("workspace-first session summary delta_bytes = %d, want 17", summary.DeltaBytes)
+	}
+}
+
 func TestHTTPUpdateWorkspaceRenamesOpaqueWorkspace(t *testing.T) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

This fixes an inconsistency in the workspace-first HTTP surface.

Before this change, the control plane supported workspace-first routes for things like workspace detail, file history, activity, events, and sessions, but it did **not** actually implement the workspace-first versions of:

- `GET /v1/workspaces/{workspace_id}/changes`
- `GET /v1/workspaces/{workspace_id}/path-last?path=...`
- `GET /v1/workspaces/{workspace_id}/sessions/{session_id}/summary`

Those requests fell through the resolved-workspace handler and returned `404` even when the workspace ID was valid.

That mattered because it made the API internally inconsistent: clients could resolve an opaque workspace ID and successfully use some workspace-first routes, then hit a dead end when trying to drill into changelog data. This was one of the concrete failures from the QA run, and it breaks any client flow that expects opaque workspace IDs to work uniformly across the workspace-first surface.

## What Changed

- added resolved manager helpers for changelog, path-last, and session-summary lookups
- implemented the missing `changes`, `path-last`, and `sessions/:id/summary` cases in `handleResolvedWorkspaceRoute`
- kept the database-scoped route behavior unchanged
- added an HTTP regression that seeds changelog data and verifies all three workspace-first routes work through an opaque `ws_...` workspace ID

## Testing

- `go test ./internal/controlplane -run TestHTTPWorkspaceFirstChangeRoutesResolveOpaqueWorkspaceID`
- `go test ./internal/controlplane`
- `make test`
