### PR TITLE
Fix UI lint regression in live-topology-card.tsx

### DIFF
--- a/ui/src/components/live-topology-card.tsx
+++ b/ui/src/components/live-topology-card.tsx
@@ -611,14 +611,14 @@ function displayLocalPath(path: string): string {
 // Prefer the session name, then the agent name; never return the hostname.
 // When neither is set, fall back to a short session id ("Session: a1b2c3d4").
 function displayAgentPrimaryName(agent: AFSAgentSession): string {
-  const host = agent.hostname?.trim() ?? "";
+  const host = agent.hostname.trim();
   const notHost = (value?: string | null) => {
     const trimmed = value?.trim();
     return trimmed && trimmed !== host ? trimmed : undefined;
   };
   const named = notHost(agent.sessionName) || notHost(agent.agentName);
   if (named) return named;
-  const shortId = agent.sessionId?.trim().slice(0, 8);
+  const shortId = agent.sessionId.trim().slice(0, 8);
   return shortId ? `Session: ${shortId}` : "Session: unknown";
 }
 
@@ -968,7 +968,7 @@ export function LiveTopologyCard({ agents, workspaces }: Props) {
       if (!group) {
         group = {
           databaseId: ws.databaseId,
-          databaseName: ws.databaseName?.trim() || "Unassigned database",
+          databaseName: ws.databaseName.trim() || "Unassigned database",
           rows: [],
         };
         groups.set(key, group);


### PR DESCRIPTION
## Summary

Fix four `@typescript-eslint/no-unnecessary-condition` errors in `ui/src/components/live-topology-card.tsx` that broke the `ui-lint` CI job on main after [#15](https://github.com/redis/agent-filesystem/pull/15) merged.

[#13](https://github.com/redis/agent-filesystem/pull/13)'s Phase 9 cleared the UI lint baseline (27 → 0) and made the `ui-lint` CI job blocking. [#14](https://github.com/redis/agent-filesystem/pull/14) (live topology redesign) introduced new optional-chain / nullish-coalesce uses on fields that the type system already proves non-null, but the timing meant Phase 9's lint sweep didn't see them. After both #14 and #15 landed on top of #13, main was red on `ui-lint`.

## What's fixed

| Line | Before | After | Reason |
|---|---|---|---|
| 614 | `agent.hostname?.trim() ?? ""` | `agent.hostname.trim()` | `hostname: string` is required; both `?.` and `??` are dead |
| 621 | `agent.sessionId?.trim().slice(0, 8)` | `agent.sessionId.trim().slice(0, 8)` | `sessionId: string` is required |
| 971 | `ws.databaseName?.trim() \|\| "..."` | `ws.databaseName.trim() \|\| "..."` | `databaseName: string` is required |

Behavior is unchanged when the runtime values match the TypeScript types (which they should, per the API contract).

## Test plan

- [x] `cd ui && npm run lint` — clean (was 4 errors, now 0)
- [x] `cd ui && npm run build` — clean
- [x] `cd ui && npm test` — 60/60 pass
- [ ] Manual sanity-check on `npm run dev` — Live Topology card renders the same agent/workspace names as before (visual no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)