### PR TITLE
Add file delete to Python and TypeScript SDKs

### DIFF
--- a/docs/reference/python.md
+++ b/docs/reference/python.md
@@ -33,6 +33,7 @@ afs.fs.mount(...)               # create an isolated SDK mount
 fs.read_file(path)              # read a text file
 fs.write_file(path, content)    # write a text file
 fs.list_files(path, depth)      # list a directory
+fs.delete(path)                 # delete a file, symlink, or empty directory
 fs.glob(pattern, ...)           # match paths
 fs.grep(pattern, **options)     # search file contents
 fs.checkpoint(name)             # checkpoint mounted workspaces
@@ -310,11 +311,16 @@ The preview `repo_names` property still works.
 fs.read_file(path: str) -> str
 fs.write_file(path: str, content: str | bytes) -> None
 fs.list_files(path: str = "/", depth: int = 1) -> list[dict[str, Any]]
+fs.delete(path: str) -> dict[str, Any]
 ```
 
 `read_file()` returns text. It raises if the path is a directory or if the
 control plane marks the file as binary. `write_file()` sends text content
-through the workspace MCP token.
+through the workspace MCP token. `delete()` removes a single file, symlink, or
+empty directory through the hosted `file_delete` MCP tool and returns its
+`{"operation": "delete", "kind": ...}` result; it refuses the workspace root and
+non-empty directories. When the mount has been materialized locally, the
+matching local path is removed too.
 
 ### Search Methods
 
@@ -459,5 +465,5 @@ fs.map_absolute_repo_paths(command)
 - `write_file()` treats `bytes` content as UTF-8 text.
 - `sync_to_remote()` writes created and modified text files, but does not
   currently propagate local file deletion.
-- `MountedFS` does not yet expose `mkdir`, `rename`, `delete`, `stat`, streams,
-  or binary file helpers.
+- `MountedFS` does not yet expose `mkdir`, `rename`, `stat`, streams, or binary
+  file helpers.

--- a/docs/reference/typescript.md
+++ b/docs/reference/typescript.md
@@ -28,6 +28,7 @@ afs.fs.mount(input)                // create an isolated SDK mount
 fs.readFile(path)                  // read a text file
 fs.writeFile(path, content)        // write a text file
 fs.listFiles(path, depth)          // list a directory
+fs.delete(path)                    // delete a file, symlink, or empty directory
 fs.glob(pattern, options)          // match paths
 fs.grep(pattern, options)          // search file contents
 fs.checkpoint(name)                // checkpoint mounted workspaces
@@ -301,11 +302,16 @@ The preview `repoNames` property still works.
 await fs.readFile(path: string): Promise<string>
 await fs.writeFile(path: string, content: string | Uint8Array): Promise<void>
 await fs.listFiles(path = "/", depth = 1): Promise<FileListItem[]>
+await fs.delete(path: string): Promise<FileDeleteResponse>
 ```
 
 `readFile()` returns text. It throws if the path is a directory or if the
 control plane marks the file as binary. `writeFile()` sends text content through
-the workspace MCP token.
+the workspace MCP token. `delete()` removes a single file, symlink, or empty
+directory through the hosted `file_delete` MCP tool and returns its
+`{ operation: "delete", kind }` result; it throws on the workspace root and
+non-empty directories. When the mount has been materialized locally, the
+matching local path is removed too.
 
 ```typescript
 type FileListItem = {
@@ -464,5 +470,5 @@ fs.mapAbsoluteRepoPaths(command)
 - `writeFile()` treats `Uint8Array` content as UTF-8 text.
 - `syncToRemote()` writes created and modified text files, but does not
   currently propagate local file deletion.
-- `MountedFS` does not yet expose `mkdir`, `rename`, `delete`, `stat`, streams,
-  or binary file helpers.
+- `MountedFS` does not yet expose `mkdir`, `rename`, `stat`, streams, or binary
+  file helpers.

--- a/sdk/python/src/redis_afs/aio/_mount.py
+++ b/sdk/python/src/redis_afs/aio/_mount.py
@@ -94,6 +94,20 @@ class AsyncMountedFS:
         workspace, remote_path = self._resolve(str(options.pop("path", "/")))
         return await workspace.client.call_tool("file_grep", {"path": remote_path, "pattern": pattern, **options})
 
+    async def delete(self, path: str) -> dict[str, Any]:
+        workspace, remote_path = self._resolve(path)
+        response = await workspace.client.call_tool("file_delete", {"path": remote_path})
+        if self.local_root:
+            local_path = self._local_path_for(workspace.name, remote_path)
+            if local_path.is_dir() and not local_path.is_symlink():
+                shutil.rmtree(local_path, ignore_errors=True)
+            else:
+                try:
+                    local_path.unlink()
+                except FileNotFoundError:
+                    pass
+        return response
+
     async def checkpoint(self, name: str | None = None) -> list[dict[str, Any]]:
         return [
             await workspace.client.call_tool("checkpoint_create", {"checkpoint": name})

--- a/sdk/python/src/redis_afs/client.py
+++ b/sdk/python/src/redis_afs/client.py
@@ -245,6 +245,20 @@ class MountedFS:
         workspace, remote_path = self._resolve_path(str(options.pop("path", "/")))
         return workspace.client.call_tool("file_grep", {"path": remote_path, "pattern": pattern, **options})
 
+    def delete(self, path: str) -> dict[str, Any]:
+        workspace, remote_path = self._resolve_path(path)
+        response = workspace.client.call_tool("file_delete", {"path": remote_path})
+        if self.local_root:
+            local_path = self._local_path_for(workspace.name, remote_path)
+            if local_path.is_dir() and not local_path.is_symlink():
+                shutil.rmtree(local_path, ignore_errors=True)
+            else:
+                try:
+                    local_path.unlink()
+                except FileNotFoundError:
+                    pass
+        return response
+
     def checkpoint(self, name: str | None = None) -> list[dict[str, Any]]:
         return [workspace.client.call_tool("checkpoint_create", {"checkpoint": name}) for workspace in self._workspaces]
 

--- a/sdk/python/tests/test_aio.py
+++ b/sdk/python/tests/test_aio.py
@@ -64,6 +64,15 @@ class FakeAsyncMCP:
             return {"path": arguments["path"], "kind": "file", "content": self.files.get(arguments["path"], "")}
         if name == "file_list":
             return {"entries": _fake_entries(self.files, self.symlinks, arguments.get("path", "/"))}
+        if name == "file_delete":
+            path = arguments["path"]
+            if path in self.files:
+                del self.files[path]
+                return {"operation": "delete", "kind": "file"}
+            if path in self.symlinks:
+                del self.symlinks[path]
+                return {"operation": "delete", "kind": "symlink"}
+            raise AssertionError(f"delete of missing path {path}")
         raise AssertionError(f"unexpected tool {name}")
 
     async def aclose(self):
@@ -86,6 +95,18 @@ def _fake_entries(files, symlinks, path):
 
 
 class AsyncClientsTest(unittest.IsolatedAsyncioTestCase):
+    async def test_delete_removes_file_and_calls_file_delete(self):
+        fake = FakeAsyncMCP()
+        fs = AsyncMountedFS([_AsyncMountedWorkspace(name="foobar", token="token", client=fake)])
+
+        await fs.write_file("/src/README.md", "hello")
+        result = await fs.delete("/foobar/src/README.md")
+
+        self.assertEqual(result, {"operation": "delete", "kind": "file"})
+        self.assertNotIn("/src/README.md", fake.files)
+        delete_paths = [args["path"] for name, args in fake.calls if name == "file_delete"]
+        self.assertEqual(delete_paths, ["/src/README.md"])
+
     async def test_workspace_list_normalizes_items(self):
         ws = AsyncWorkspaceClient(FakeAsyncMCP())
         self.assertEqual(await ws.list(), [{"name": "a"}, {"name": "b"}])

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -47,6 +47,15 @@ class FakeMCP:
                     if "/" not in remainder:
                         entries.append({"path": link_path, "name": remainder, "kind": "symlink", "target": target})
             return {"entries": entries}
+        if name == "file_delete":
+            path = arguments["path"]
+            if path in self.files:
+                del self.files[path]
+                return {"operation": "delete", "kind": "file"}
+            if path in self.symlinks:
+                del self.symlinks[path]
+                return {"operation": "delete", "kind": "symlink"}
+            raise AssertionError(f"delete of missing path {path}")
         if name == "checkpoint_create":
             return {"workspace": "workspace", "checkpoint": arguments.get("checkpoint") or "save-20260508-000000.000", "created": True}
         if name == "checkpoint_restore":
@@ -124,6 +133,18 @@ class MountedFSTest(unittest.TestCase):
         self.assertEqual(fake.files["/src/README.md"], "hello")
         self.assertEqual(fs.read_file("/foobar/src/README.md"), "hello")
         self.assertEqual(fs.workspace_names, ["foobar"])
+
+    def test_delete_removes_file_and_calls_file_delete(self):
+        fake = FakeMCP()
+        fs = MountedFS([_MountedWorkspace(name="foobar", token="token", client=fake)])
+
+        fs.write_file("/src/README.md", "hello")
+        result = fs.delete("/foobar/src/README.md")
+
+        self.assertEqual(result, {"operation": "delete", "kind": "file"})
+        self.assertNotIn("/src/README.md", fake.files)
+        delete_paths = [args["path"] for name, args in fake.calls if name == "file_delete"]
+        self.assertEqual(delete_paths, ["/src/README.md"])
 
     def test_multi_workspace_requires_workspace_prefix(self):
         fs = MountedFS(

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -142,6 +142,11 @@ export type FileReadResponse = {
   target?: string;
 };
 
+export type FileDeleteResponse = {
+  operation: "delete";
+  kind: "file" | "dir" | "symlink" | string;
+};
+
 export class AFSError extends Error {
   readonly status?: number;
   readonly code?: number;
@@ -381,6 +386,18 @@ export class MountedFS {
       path: resolved.remotePath,
       pattern,
     });
+  }
+
+  async delete(path: string): Promise<FileDeleteResponse> {
+    const resolved = this.resolvePath(path);
+    const response = await resolved.workspace.client.callTool<FileDeleteResponse>("file_delete", {
+      path: resolved.remotePath,
+    });
+    if (this.localRootPath) {
+      const localPath = this.localPathFor(resolved.workspace.name, resolved.remotePath);
+      await rm(localPath, { recursive: true, force: true });
+    }
+    return response;
   }
 
   async checkpoint(name?: string): Promise<{ workspace: string; checkpoint: string; created: boolean }[]> {

--- a/sdk/typescript/test/sdk.test.mjs
+++ b/sdk/typescript/test/sdk.test.mjs
@@ -57,6 +57,37 @@ test("single-workspace mounts allow workspace-relative paths", async () => {
   assert.deepEqual(fs.workspaceNames, ["foobar"]);
 });
 
+test("delete removes a file and calls file_delete", async () => {
+  const files = new Map();
+  const calls = [];
+  const fakeClient = {
+    async callTool(name, args = {}) {
+      calls.push([name, args]);
+      if (name === "file_write") {
+        files.set(args.path, args.content);
+        return { operation: "write" };
+      }
+      if (name === "file_delete") {
+        if (!files.has(args.path)) {
+          throw new Error(`delete of missing path ${args.path}`);
+        }
+        files.delete(args.path);
+        return { operation: "delete", kind: "file" };
+      }
+      throw new Error(`unexpected tool ${name}`);
+    },
+  };
+  const fs = new MountedFS([{ name: "foobar", token: "token", client: fakeClient }], { mode: "rw" });
+
+  await fs.writeFile("/src/README.md", "hello");
+  const result = await fs.delete("/foobar/src/README.md");
+
+  assert.deepEqual(result, { operation: "delete", kind: "file" });
+  assert.equal(files.has("/src/README.md"), false);
+  const deletePaths = calls.filter(([name]) => name === "file_delete").map(([, args]) => args.path);
+  assert.deepEqual(deletePaths, ["/src/README.md"]);
+});
+
 test("checkpoint.create and checkpoint.restore round-trip through MCP", async () => {
   const calls = [];
   const afs = new AFS({


### PR DESCRIPTION
## Summary

The hosted `file_delete` MCP tool already exists, but neither mounted-FS SDK exposed it. This adds `delete(path)` to the mounted filesystem in both SDKs at parity.

- **Python** — `MountedFS.delete` (sync) and `AsyncMountedFS.delete` (async)
- **TypeScript** — `MountedFS.delete`, plus a `FileDeleteResponse` type

Each mirrors `write_file`: resolve the workspace-relative path, call `file_delete`, and remove the local mirror entry when the mount has been materialized locally.

## Behavior

- Returns the tool result `{ operation: "delete", kind }`, where `kind` is `"file"`, `"dir"` (empty), or `"symlink"`.
- The workspace root and non-empty directories are rejected backend-side and surface as a raised error.
- No backend changes — works against the deployed control plane today.

## Tests

- New unit tests for sync, async, and TypeScript delete (against mocked MCP clients; return shape matches the Go handlers).
- Python: 41 passing. TypeScript: 6 passing, type-check clean.

## Docs

Updated the Python and TypeScript reference docs (quick reference, signatures, and the "not yet exposed" limits list).