### PR TITLE
Fix Docker build: copy scripts/ and templates/ into the UI stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,12 @@ WORKDIR /build/ui
 COPY ui/package.json ui/package-lock.json ./
 RUN npm ci
 
+# The UI's prebuild step runs ../scripts/generate-template-data.mjs, which reads
+# the repo-root templates/ tree. Both live outside ui/, so they have to be copied
+# in or `npm run build` fails before vite starts.
+COPY scripts/ /build/scripts/
+COPY templates/ /build/templates/
+
 COPY ui/ ./
 RUN npm run build
 


### PR DESCRIPTION
## Problem

`docker build .` fails on a clean checkout.

The `ui-builder` stage sets `WORKDIR /build/ui` and copies only `ui/`, but `ui/package.json` runs a prebuild step that reaches outside that directory:

```json
"prebuild": "npm run templates:generate",
"templates:generate": "node ../scripts/generate-template-data.mjs"
```

From `/build/ui` that resolves to `/build/scripts/generate-template-data.mjs`, which is never copied in:

```
> node ../scripts/generate-template-data.mjs
Error: Cannot find module '/build/scripts/generate-template-data.mjs'
```

Adding `scripts/` alone is not sufficient — the generator then walks the repo-root `templates/` tree:

```
Error: ENOENT: no such file or directory, scandir '/build/templates'
```

This also affects `docker compose up`, which the README documents as the self-managed path, since the `afs` service builds from this Dockerfile.

## Fix

Copy both directories into the UI build stage. Two lines, no behaviour change.

## Verification

Built on `linux/arm64` from a clean checkout:

- image builds successfully
- `GET /healthz` → `200`
- `GET /` serves the embedded UI (`<!doctype html>` with the Redis AFS favicon)

Both the generated template data and the vite output end up embedded correctly, so this exercises the whole path rather than just getting past the failing step.

## Notes

Found while building an AFS deployment for Kubernetes, where I needed a control-plane image. I had to carry a patched copy of this Dockerfile downstream; this removes that need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)