### PR TITLE
mount: add --uid/--gid to set file ownership in the mount

### DIFF
--- a/mount/cmd/agent-filesystem-mount/main.go
+++ b/mount/cmd/agent-filesystem-mount/main.go
@@ -35,6 +35,8 @@ func main() {
 	attrTimeout := flag.Float64("attr-timeout", 1.0, "Attribute cache TTL in seconds")
 	readOnly := flag.Bool("readonly", false, "Mount read-only")
 	allowOther := flag.Bool("allow-other", false, "Allow other users to access mount")
+	mountUID := flag.Int("uid", -1, "Owner uid for files in the mount (default: the mount process's uid)")
+	mountGID := flag.Int("gid", -1, "Owner gid for files in the mount (default: the mount process's gid)")
 	foreground := flag.Bool("foreground", true, "Run in foreground")
 	debug := flag.Bool("debug", false, "Enable FUSE debug logging")
 	disableInvalidation := flag.Bool("disable-cross-client-invalidation", false, "Disable Redis pub/sub cache invalidation between clients. Falls back to TTL-based staleness.")
@@ -116,7 +118,17 @@ func main() {
 
 	c := client.NewWithObserver(rdb, redisKey, controlplane.NewMountVersionObserver(rdb))
 
+	// Ownership defaults to the mount process's own uid/gid. The flags let a
+	// privileged mounter present the files as another user, which is what
+	// container and CSI callers need: without them the only way to hand a mount
+	// to a non-root workload is to run the mount process as that user.
 	uid, gid := afsfs.GetOwnership()
+	if *mountUID >= 0 {
+		uid = uint32(*mountUID)
+	}
+	if *mountGID >= 0 {
+		gid = uint32(*mountGID)
+	}
 
 	opts := &afsfs.Options{
 		AttrTimeout:                    time.Duration(*attrTimeout * float64(time.Second)),

--- a/mount/internal/afsfs/fs.go
+++ b/mount/internal/afsfs/fs.go
@@ -384,7 +384,9 @@ func (n *FSNode) Setattr(ctx context.Context, fh fs.FileHandle, in *fuse.SetAttr
 	return n.Getattr(ctx, fh, out)
 }
 
-// GetOwnership returns the uid/gid to use. Defaults come from opts.
+// GetOwnership returns the calling process's uid/gid, the default owner for
+// files in a mount. Callers that need a different owner set Options.UID and
+// Options.GID instead.
 func GetOwnership() (uint32, uint32) {
 	return uint32(os.Getuid()), uint32(os.Getgid())
 }


### PR DESCRIPTION
## Problem

`agent-filesystem-mount` can only present files as the uid/gid of its own process. `main.go` takes ownership solely from `afsfs.GetOwnership()`, which returns `os.Getuid()/os.Getgid()`.

The plumbing to do better already exists — `afsfs.Options` carries `UID`/`GID` and `Mount()` passes them to go-fuse — only the command line couldn't reach it. `GetOwnership`'s doc comment even claimed *"Defaults come from opts"* while taking no opts; corrected here.

## Why it matters beyond the CLI

To hand a mount to a **non-root workload** today, the mount process itself must run as that user. In a container that pulls in two non-obvious requirements, because `fusermount3` needs both:

- `/etc/mtab` — absent from slim images (`failed to open /etc/mtab`)
- a passwd entry for the uid, or it aborts with `could not determine username`

With `--uid/--gid` the mount stays root while presenting files as the workload user, and that whole class of setup disappears.

I hit this writing a CSI driver that mounts AFS volumes into Kubernetes pods. It currently runs each mount process under the target uid and synthesizes an `/etc/passwd` entry to compensate; this change lets that go away.

## Change

Two flags defaulting to `-1` (unset), so **behaviour is unchanged unless a caller opts in**. 15 insertions.

## Verification

Real FUSE mount on `linux/arm64`, mount process running as **root**, against Redis 8.8.1:

| Mount process | Flags | Resulting file owner |
| --- | --- | --- |
| uid 0 | `--uid 1000 --gid 1000` | **1000:1000**, writes succeed |
| uid 0 | none | 0:0 — unchanged default |

Both files and directories report the requested owner, and content reads back correctly. `go vet ./...` and the `mount` module test suite pass.

## Possible follow-up

If useful, the same two flags would apply to `agent-filesystem-nfs`. Left out here to keep the change focused — happy to add them if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)